### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @github/c2c-actions-experience-parser-reviewers
+* @actions/actions-experience


### PR DESCRIPTION
The current team isn't valid within the `actions` org. We will likely change this in the future, but for now let's use an existing team.