### PR TITLE
Felipesu19 fix workflow token

### DIFF
--- a/workflow-parser/src/model/converter/events.ts
+++ b/workflow-parser/src/model/converter/events.ts
@@ -60,18 +60,28 @@ export function convertOn(context: TemplateContext, token: TemplateToken): Event
       // All other events are defined as mappings. During schema validation we already ensure that events
       // receive only known keys, so here we can focus on the values and whether they are valid.
       const eventToken = item.value.assertMapping(`event ${eventName}`);
-
-      result[eventName] = {
-        ...convertPatternFilter("branches", eventToken),
-        ...convertPatternFilter("tags", eventToken),
-        ...convertPatternFilter("paths", eventToken),
-        ...convertFilter("types", eventToken),
-        ...convertFilter("workflows", eventToken),
-        // workflow_call and workflow_dispatch share input parsing
-        ...convertEventWorkflowDispatchInputs(context, eventToken),
-        ...convertEventWorkflowCall(context, eventToken)
-      };
+      if(eventName === "workflow_call") {
+        result[eventName] = {
+          ...convertPatternFilter("branches", eventToken),
+          ...convertPatternFilter("tags", eventToken),
+          ...convertPatternFilter("paths", eventToken),
+          ...convertFilter("types", eventToken),
+          ...convertFilter("workflows", eventToken),
+          ...convertEventWorkflowCall(context, eventToken)
+        };
+      }else{
+        result[eventName] = {
+          ...convertPatternFilter("branches", eventToken),
+          ...convertPatternFilter("tags", eventToken),
+          ...convertPatternFilter("paths", eventToken),
+          ...convertFilter("types", eventToken),
+          ...convertFilter("workflows", eventToken),
+          ...convertEventWorkflowDispatchInputs(context, eventToken),
+        };
+      }
     }
+  
+    
 
     return result;
   }

--- a/workflow-parser/src/model/converter/events.ts
+++ b/workflow-parser/src/model/converter/events.ts
@@ -59,29 +59,26 @@ export function convertOn(context: TemplateContext, token: TemplateToken): Event
 
       // All other events are defined as mappings. During schema validation we already ensure that events
       // receive only known keys, so here we can focus on the values and whether they are valid.
+
       const eventToken = item.value.assertMapping(`event ${eventName}`);
-      if(eventName === "workflow_call") {
-        result[eventName] = {
-          ...convertPatternFilter("branches", eventToken),
-          ...convertPatternFilter("tags", eventToken),
-          ...convertPatternFilter("paths", eventToken),
-          ...convertFilter("types", eventToken),
-          ...convertFilter("workflows", eventToken),
-          ...convertEventWorkflowCall(context, eventToken)
-        };
-      }else{
-        result[eventName] = {
-          ...convertPatternFilter("branches", eventToken),
-          ...convertPatternFilter("tags", eventToken),
-          ...convertPatternFilter("paths", eventToken),
-          ...convertFilter("types", eventToken),
-          ...convertFilter("workflows", eventToken),
-          ...convertEventWorkflowDispatchInputs(context, eventToken),
-        };
+      if (eventName === "workflow_call") {
+        result.workflow_call = convertEventWorkflowCall(context, eventToken);
+        continue;
       }
+
+      if (eventName === "workflow_dispatch") {
+        result.workflow_dispatch = convertEventWorkflowDispatchInputs(context, eventToken);
+        continue;
+      }
+
+      result[eventName] = {
+        ...convertPatternFilter("branches", eventToken),
+        ...convertPatternFilter("tags", eventToken),
+        ...convertPatternFilter("paths", eventToken),
+        ...convertFilter("types", eventToken),
+        ...convertFilter("workflows", eventToken)
+      };
     }
-  
-    
 
     return result;
   }

--- a/workflow-parser/src/model/converter/workflow-call.ts
+++ b/workflow-parser/src/model/converter/workflow-call.ts
@@ -1,7 +1,9 @@
 import {TemplateContext} from "../../templates/template-context";
 import {MappingToken, TemplateToken} from "../../templates/tokens";
 import {isMapping} from "../../templates/tokens/type-guards";
-import {SecretConfig, WorkflowCallConfig} from "../workflow-template";
+import {SecretConfig, WorkflowCallConfig, InputConfig,InputType} from "../workflow-template";
+import {convertStringList} from "./string-list";
+import {ScalarToken} from "../../templates/tokens/scalar-token";
 
 export function convertEventWorkflowCall(context: TemplateContext, token: MappingToken): WorkflowCallConfig {
   const result: WorkflowCallConfig = {};
@@ -11,7 +13,7 @@ export function convertEventWorkflowCall(context: TemplateContext, token: Mappin
 
     switch (key.value) {
       case "inputs":
-        // Ignore, these are handled by convertEventWorkflowDispatchInputs
+        result.inputs = convertWorkflowInputs(context, item.value.assertMapping("workflow dispatch inputs"));
         break;
 
       case "secrets":
@@ -21,6 +23,95 @@ export function convertEventWorkflowCall(context: TemplateContext, token: Mappin
       case "outputs":
         // TODO - outputs
         break;
+    }
+  }
+
+  return result;
+}
+
+
+export function convertWorkflowInputs(
+  context: TemplateContext,
+  token: MappingToken
+): {
+  [inputName: string]: InputConfig;
+} {
+  const result: {[inputName: string]: InputConfig} = {};
+
+  for (const item of token) {
+    const inputName = item.key.assertString("input name");
+    const inputMapping = item.value.assertMapping("input configuration");
+
+    result[inputName.value] = convertWorkflowInput(context, inputMapping);
+  }
+
+  return result;
+}
+
+export function convertWorkflowInput(context: TemplateContext, token: MappingToken): InputConfig {
+  const result: InputConfig = {
+    type: InputType.string // Default to string
+  };
+
+  let defaultValue: undefined | ScalarToken;
+
+  for (const item of token) {
+    const key = item.key.assertString("workflow dispatch input key");
+
+    switch (key.value) {
+      case "description":
+        result.description = item.value.assertString("input description").value;
+        break;
+
+      case "required":
+        result.required = item.value.assertBoolean("input required").value;
+        break;
+
+      case "default":
+        defaultValue = item.value.assertScalar("input default");
+        break;
+
+      case "type":
+        result.type = InputType[item.value.assertString("input type").value as keyof typeof InputType];
+        break;
+
+      case "options":
+        result.options = convertStringList("input options", item.value.assertSequence("input options"));
+        break;
+
+      default:
+        context.error(item.key, `Invalid key '${key.value}'`);
+    }
+  }
+
+  // Validate default value
+  if (defaultValue !== undefined) {
+    try {
+      switch (result.type) {
+        case InputType.boolean:
+          result.default = defaultValue.assertBoolean("input default").value;
+
+          break;
+
+        case InputType.string:
+        case InputType.choice:
+        case InputType.environment:
+          result.default = defaultValue.assertString("input default").value;
+          break;
+      }
+    } catch (e) {
+      context.error(defaultValue, e);
+    }
+  }
+
+  // Validate `options` for `choice` type
+  if (result.type === InputType.choice) {
+    if (result.options === undefined || result.options.length === 0) {
+      context.error(token, "Missing 'options' for choice input");
+    }
+  } else {
+    if (result.options !== undefined) {
+      context.error(token, "Input type is not 'choice', but 'options' is defined");
     }
   }
 

--- a/workflow-parser/src/model/converter/workflow-call.ts
+++ b/workflow-parser/src/model/converter/workflow-call.ts
@@ -1,7 +1,7 @@
 import {TemplateContext} from "../../templates/template-context";
 import {MappingToken, TemplateToken} from "../../templates/tokens";
 import {isMapping} from "../../templates/tokens/type-guards";
-import {SecretConfig, WorkflowCallConfig, InputConfig,InputType} from "../workflow-template";
+import {SecretConfig, WorkflowCallConfig, InputConfig, InputType} from "../workflow-template";
 import {convertStringList} from "./string-list";
 import {ScalarToken} from "../../templates/tokens/scalar-token";
 
@@ -28,7 +28,6 @@ export function convertEventWorkflowCall(context: TemplateContext, token: Mappin
 
   return result;
 }
-
 
 export function convertWorkflowInputs(
   context: TemplateContext,
@@ -85,7 +84,7 @@ export function convertWorkflowInput(context: TemplateContext, token: MappingTok
   }
 
   // Validate default value
-  if (defaultValue !== undefined) {
+  if (defaultValue !== undefined && !defaultValue.isExpression) {
     try {
       switch (result.type) {
         case InputType.boolean:

--- a/workflow-parser/src/model/workflow-template.ts
+++ b/workflow-parser/src/model/workflow-template.ts
@@ -158,7 +158,7 @@ export type WorkflowDispatchConfig = {
 };
 
 export type WorkflowCallConfig = {
-  inputs?: {[inputName: string]: InputConfig};
+  inputs?: {[inputName: string]: InputConfig & {default?: string | boolean | number | ScalarToken}};
   secrets?: {[secretName: string]: SecretConfig};
   // TODO - these are supported in C# and Go but not in TS yet
   // outputs: { [outputName: string]: OutputConfig }


### PR DESCRIPTION
Fixes: https://github.com/github/vscode-github-actions/issues/54

After conversation with @joshmgross, the summary of what is happening here is as follows: 

1. Originally we assumed the behavior of workflow-dispatch and workflow-call needed to be the same. There is a subtle difference where the workflow-call can interpolate a variable in the description. 
2. To fix this we had to split the logic apart and have different behaviors for each 
3. Importantly the block for validating the default value in workflow-dispatch reads `if(defaultValue !== undefined)` which handles all cases where the value is set, *including* expressions, which we want to skip
4. The logic in workflow-call now *skips* the validation step if the default value is an expression. 

We did *not* have to change the InputConfig.type as I had originally thought

Screenshot of correct behavior: 
![Screenshot 2023-04-06 at 2 28 26 PM](https://user-images.githubusercontent.com/85468376/230473760-1646fe37-6949-4bf8-afdb-49bc11efd3e3.png)
