### PR TITLE
Fix Reusable Workflow Reference for Windows by using vscodeURI instead of path.join

### DIFF
--- a/languageserver/src/file-provider.ts
+++ b/languageserver/src/file-provider.ts
@@ -4,6 +4,7 @@ import {fileIdentifier} from "@actions/workflow-parser/workflows/file-reference"
 import {Octokit} from "@octokit/rest";
 import path from "path";
 import {TTLCache} from "./utils/cache";
+import vscodeURI from "vscode-uri/lib/umd"; // work around issues with the vscode-uri package
 
 export function getFileProvider(
   client: Octokit | undefined,
@@ -31,7 +32,10 @@ export function getFileProvider(
         throw new Error("Local file references are not supported with this configuration");
       }
 
-      const file = await readFile(path.join(workspace, ref.path));
+      const workspaceURI = vscodeURI.URI.parse(workspace);
+      const path = vscodeURI.Utils.joinPath(workspaceURI, ref.path);
+      const file = await readFile(path.toString());
+
       if (!file) {
         throw new Error(`File not found: ${ref.path}`);
       }

--- a/languageserver/src/file-provider.ts
+++ b/languageserver/src/file-provider.ts
@@ -2,9 +2,8 @@ import {File} from "@actions/workflow-parser/workflows/file";
 import {FileProvider} from "@actions/workflow-parser/workflows/file-provider";
 import {fileIdentifier} from "@actions/workflow-parser/workflows/file-reference";
 import {Octokit} from "@octokit/rest";
-import path from "path";
 import {TTLCache} from "./utils/cache";
-import vscodeURI from "vscode-uri/lib/umd"; // work around issues with the vscode-uri package
+import vscodeURI from "vscode-uri/lib/umd";
 
 export function getFileProvider(
   client: Octokit | undefined,

--- a/languageserver/src/file-provider.ts
+++ b/languageserver/src/file-provider.ts
@@ -32,8 +32,8 @@ export function getFileProvider(
       }
 
       const workspaceURI = vscodeURI.URI.parse(workspace);
-      const path = vscodeURI.Utils.joinPath(workspaceURI, ref.path);
-      const file = await readFile(path.toString());
+      const refURI = vscodeURI.Utils.joinPath(workspaceURI, ref.path);
+      const file = await readFile(refURI.toString());
 
       if (!file) {
         throw new Error(`File not found: ${ref.path}`);


### PR DESCRIPTION
Closes https://github.com/github/vscode-github-actions/issues/68

Issue:
- Reusable workflows on Windows were showing red squiggly marks under a reusable workflow local path (in the same repo) and were not able to find them. I tested on Mac and they worked fine there, but it was broken on Windows.  
- ![image](https://user-images.githubusercontent.com/7976517/232915659-171bc6ee-cec2-4ec2-91e7-6e2985f77f3a.png)

The reusable workflow does work on dotcom and I tested running the workflow to ensure it was a correct reusable workflow path and that the red squiggly marks were the error. 
![image](https://user-images.githubusercontent.com/7976517/232915790-1ebc10d2-71e9-4b6d-9568-f7a43c9a16d6.png)

Reason for the red squiggly issue on Windows:
- `path.join` does not work for all OS. It was working for Mac.
- `vscodeURI.Utils.joinPath` is a much more cross platform solution, so I replaced `path.join` with this. 

Demo of it working after fix:
![reusableworkflowfix](https://user-images.githubusercontent.com/7976517/232914948-b7d9c05e-d172-43f7-8b75-869e8a8690db.gif)
