### PR TITLE
Add the ability to handle double quotes in an Actions Expression

### DIFF
--- a/expressions/src/lexer.ts
+++ b/expressions/src/lexer.ts
@@ -179,6 +179,7 @@ export class Lexer {
           break;
 
         case "'":
+        case '"':
           this.consumeString();
           break;
 
@@ -299,8 +300,13 @@ export class Lexer {
   }
 
   private consumeString() {
-    while ((this.peek() !== "'" || this.peekNext() === "'") && !this.atEnd()) {
+    // TODO: Should I make these consume double quotes as well?
+    const isSingleQuote = (this.peek() !== "'" || this.peekNext() === "'");
+    const isDoubleQuote = (this.peek() !== '"' || this.peekNext() === '"');
+
+    while ((isSingleQuote || isDoubleQuote) && !this.atEnd()) {
       if (this.peek() === "\n") this.line++;
+      // TODO: Should I also add this for double quotes?
       if (this.peek() === "'" && this.peekNext() === "'") {
         // Escaped "'", consume
         this.next();


### PR DESCRIPTION
Closes https://github.com/github/vscode-github-actions/issues/60

YAML strings can either start with a single or double quote. We currently do not support the ability to handle double quoted strings.