### PR TITLE
Update @octokit/types

### DIFF
--- a/languageserver/package.json
+++ b/languageserver/package.json
@@ -46,7 +46,7 @@
     "@actions/languageservice": "^0.3.4",
     "@actions/workflow-parser": "^0.3.4",
     "@octokit/rest": "^19.0.7",
-    "@octokit/types": "^9.0.0",
+    "@octokit/types": "^9.1.2",
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.7",
     "yaml": "^2.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -401,7 +401,7 @@
         "@actions/languageservice": "^0.3.4",
         "@actions/workflow-parser": "^0.3.4",
         "@octokit/rest": "^19.0.7",
-        "@octokit/types": "^9.0.0",
+        "@octokit/types": "~9.1.2",
         "vscode-languageserver": "^8.0.2",
         "vscode-languageserver-textdocument": "^1.0.7",
         "yaml": "^2.1.3"
@@ -462,16 +462,16 @@
       }
     },
     "languageserver/node_modules/@octokit/openapi-types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.0.0.tgz",
+      "integrity": "sha512-V8BVJGN0ZmMlURF55VFHFd/L92XQQ43KvFjNmY1IYbCN3V/h/uUFV6iQi19WEHM395Nn+1qhUbViCAD/1czzog=="
     },
     "languageserver/node_modules/@octokit/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.1.2.tgz",
+      "integrity": "sha512-LPbJIuu1WNoRHbN4UMysEdlissRFpTCWyoKT7kHPufI8T+XX33/qilfMWJo3mCOjNIKu0+43oSQPf+HJa0+TTQ==",
       "dependencies": {
-        "@octokit/openapi-types": "^16.0.0"
+        "@octokit/openapi-types": "^17.0.0"
       }
     },
     "languageserver/node_modules/argparse": {


### PR DESCRIPTION
We ran into issues when running `npm run build` in the `/languageserver` project. Updating the `@octokit/types` seems to fix this.