### PR TITLE
Read in self signed-cert

### DIFF
--- a/languageserver/package.json
+++ b/languageserver/package.json
@@ -47,8 +47,11 @@
     "@actions/workflow-parser": "^0.3.4",
     "@octokit/rest": "^19.0.7",
     "@octokit/types": "^9.0.0",
+    "@roamhq/mac-ca": "^1.0.7",
+    "node-forge": "^1.3.1",
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.7",
+    "win-ca": "^3.5.0",
     "yaml": "^2.1.3"
   },
   "engines": {

--- a/languageserver/src/certificate-reader.ts
+++ b/languageserver/src/certificate-reader.ts
@@ -1,0 +1,35 @@
+export class CertificateReader {
+  getAllRootCAs(): string[] {
+    switch (process.platform) {
+      case "darwin":
+        return this.getMacOSCerts();
+      case "win32":
+        return this.getWindowsCerts();
+      default:
+        // We only support self-signed certs from Windows anc MacOS
+        return [];
+    }
+  }
+
+  private getMacOSCerts(): string[] {
+    // loading modules here prevents unnecessary module loading
+    // see: https://stackoverflow.com/questions/9132772/lazy-loading-in-node-js
+    const macCa = require("@roamhq/mac-ca");
+    const forge = require("node-forge");
+
+    return macCa.all().map((cert: any) => forge.pki.certificateToPem(cert));
+  }
+
+  private getWindowsCerts(): string[] {
+    const ca = require("win-ca");
+
+    let rootCAs: string[] = [];
+
+    ca({
+      format: ca.der2.pem,
+      ondata: (crt: string) => rootCAs.push(crt)
+    });
+
+    return rootCAs;
+  }
+}

--- a/languageserver/src/client.ts
+++ b/languageserver/src/client.ts
@@ -1,8 +1,28 @@
 import {Octokit} from "@octokit/rest";
+import { Agent } from "node:https";
+import { readFileSync } from "fs";
 
 export function getClient(token: string, userAgent?: string): Octokit {
-  return new Octokit({
-    auth: token,
-    userAgent: userAgent || `GitHub Actions Language Server`
-  });
+  const selfSignedCertPath = process.env.NODE_EXTRA_CA_CERTS;
+
+  // if NODE_EXTRA_CA_CERTS is set then use the self-signed cert to make the request
+  if (selfSignedCertPath) {
+    const httpsAgent = new Agent({
+      ca: readFileSync(selfSignedCertPath)
+    });
+
+    return new Octokit({
+      auth: token,
+      userAgent: userAgent || `GitHub Actions Language Server`,
+      request: {
+        agent: httpsAgent
+      },
+    });
+
+  } else {
+    return new Octokit({
+      auth: token,
+      userAgent: userAgent || `GitHub Actions Language Server`
+    });
+  }
 }

--- a/languageserver/src/client.ts
+++ b/languageserver/src/client.ts
@@ -1,6 +1,6 @@
 import {Octokit} from "@octokit/rest";
-import { Agent } from "node:https";
-import { readFileSync } from "fs";
+import {Agent} from "node:https";
+import {readFileSync} from "fs";
 
 export function getClient(token: string, userAgent?: string): Octokit {
   const selfSignedCertPath = process.env.PATH_TO_SELF_SIGNED_CERT;
@@ -15,9 +15,8 @@ export function getClient(token: string, userAgent?: string): Octokit {
       userAgent: userAgent || `GitHub Actions Language Server`,
       request: {
         agent: httpsAgent
-      },
+      }
     });
-
   } else {
     return new Octokit({
       auth: token,

--- a/languageserver/src/client.ts
+++ b/languageserver/src/client.ts
@@ -1,15 +1,14 @@
 import {Octokit} from "@octokit/rest";
 import {Agent} from "node:https";
-import { CertificateReader } from "./certificate-reader";
+import {CertificateReader} from "./certificate-reader";
 
 export function getClient(token: string, userAgent?: string): Octokit {
-
   const certReader = new CertificateReader();
   const selfSignedCerts = certReader.getAllRootCAs();
 
   if (selfSignedCerts.length > 0) {
     const httpsAgent = new Agent({
-      ca: selfSignedCerts,
+      ca: selfSignedCerts
     });
 
     return new Octokit({

--- a/languageserver/src/client.ts
+++ b/languageserver/src/client.ts
@@ -1,13 +1,15 @@
 import {Octokit} from "@octokit/rest";
 import {Agent} from "node:https";
-import {readFileSync} from "fs";
+import { CertificateReader } from "./certificate-reader";
 
 export function getClient(token: string, userAgent?: string): Octokit {
-  const selfSignedCertPath = process.env.PATH_TO_SELF_SIGNED_CERT;
 
-  if (selfSignedCertPath) {
+  const certReader = new CertificateReader();
+  const selfSignedCerts = certReader.getAllRootCAs();
+
+  if (selfSignedCerts.length > 0) {
     const httpsAgent = new Agent({
-      ca: readFileSync(selfSignedCertPath)
+      ca: selfSignedCerts,
     });
 
     return new Octokit({

--- a/languageserver/src/client.ts
+++ b/languageserver/src/client.ts
@@ -3,9 +3,8 @@ import { Agent } from "node:https";
 import { readFileSync } from "fs";
 
 export function getClient(token: string, userAgent?: string): Octokit {
-  const selfSignedCertPath = process.env.NODE_EXTRA_CA_CERTS;
+  const selfSignedCertPath = process.env.PATH_TO_SELF_SIGNED_CERT;
 
-  // if NODE_EXTRA_CA_CERTS is set then use the self-signed cert to make the request
   if (selfSignedCertPath) {
     const httpsAgent = new Agent({
       ca: readFileSync(selfSignedCertPath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -402,8 +402,11 @@
         "@actions/workflow-parser": "^0.3.4",
         "@octokit/rest": "^19.0.7",
         "@octokit/types": "^9.0.0",
+        "@roamhq/mac-ca": "^1.0.7",
+        "node-forge": "^1.3.1",
         "vscode-languageserver": "^8.0.2",
         "vscode-languageserver-textdocument": "^1.0.7",
+        "win-ca": "^3.5.0",
         "yaml": "^2.1.3"
       },
       "devDependencies": {
@@ -3693,6 +3696,14 @@
       },
       "peerDependencies": {
         "typescript": "^3 || ^4"
+      }
+    },
+    "node_modules/@roamhq/mac-ca": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@roamhq/mac-ca/-/mac-ca-1.0.7.tgz",
+      "integrity": "sha512-AOHGY1R0pH+dWJueA5i1gx2V19CLfDa8ojanhyd5ZSI/YDZ3szDr0NSDntFgWGKsvT4TtvNZfDWmXuwbSY9fTg==",
+      "dependencies": {
+        "node-forge": "^1.3.1"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -6998,6 +7009,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -8708,6 +8724,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp": {
@@ -10688,7 +10712,6 @@
     },
     "node_modules/split": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "through": "2"
@@ -10954,7 +10977,6 @@
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -11467,6 +11489,37 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/win-ca": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/win-ca/-/win-ca-3.5.0.tgz",
+      "integrity": "sha512-0TgO/+2iz2pS3OxBy2ikovPHOYyZRdLRxRTT9ze7DpZwEpaahLFOBuac93GM3lYEVzDyf8fXskJjIX/EILvkhQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "is-electron": "^2.2.0",
+        "make-dir": "^1.3.0",
+        "node-forge": "^1.2.1",
+        "split": "^1.0.1"
+      }
+    },
+    "node_modules/win-ca/node_modules/make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/win-ca/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/word-wrap": {


### PR DESCRIPTION
Closes https://github.com/github/vscode-github-actions/issues/39

## Background & Context

We have users that have self-signed CA certificates that are issued by an internal CA.  This solution reads the certificate (provided by the user as an env var) and instantiates a Node HTTPS agent to make the request.

Octokit allows you to pass your own HTTP/HTTPS agent.