### PR TITLE
Update lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "useWorkspaces": true,
   "version": "0.3.5"
 }


### PR DESCRIPTION
The current version of lerna doesn't use useWorkspaces anymore, defaulting to using the workspace config if one exists: 

```
ECONFIGWORKSPACES The "useWorkspaces" option has been removed. By default lerna will resolve your packages using your package manager's workspaces configuration. Alternatively, you can manually provide a list of package globs to be used instead via the "packages" option in lerna.json.
```