### PR TITLE
Update schema with attestations permission

### DIFF
--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -1515,6 +1515,10 @@
             "type": "permission-level-any",
             "description": "Actions workflows, workflow runs, and artifacts."
           },
+          "attestations": {
+            "type": "permission-level-any",
+            "description": "Artifact attestations."
+          },
           "checks": {
             "type": "permission-level-any",
             "description": "Check runs and check suites."


### PR DESCRIPTION
Updates `workflow-v1.0.json` with support for the new `attestations` permission (per the [artifact attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds#generating-artifact-attestations-for-your-builds) feature).

I wasn't sure if I should add a test for this change as it appeared that all of the existing tests dealing with permissions were on the skipped-tests list.