### PR TITLE
Update schema to allow for `github-pages` in `job-environment-name`

### DIFF
--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -1970,6 +1970,7 @@
       "description": "The name of the environment used by the job.",
       "context": [
         "github",
+        "github-pages",
         "inputs",
         "vars",
         "needs",


### PR DESCRIPTION
Just trying to make #74 more actionable.

I'm not familiar with this schema, so it might make sense to add the value in other places as well. Or maybe this is the wrong approach altogether.