### PR TITLE
Change vscode-uri import syntax

### DIFF
--- a/languageserver/src/file-provider.ts
+++ b/languageserver/src/file-provider.ts
@@ -3,7 +3,7 @@ import {FileProvider} from "@actions/workflow-parser/workflows/file-provider";
 import {fileIdentifier} from "@actions/workflow-parser/workflows/file-reference";
 import {Octokit} from "@octokit/rest";
 import {TTLCache} from "./utils/cache";
-import vscodeURI from "vscode-uri/lib/umd";
+import * as vscodeURI from "vscode-uri";
 
 export function getFileProvider(
   client: Octokit | undefined,

--- a/languageservice/package.json
+++ b/languageservice/package.json
@@ -48,7 +48,7 @@
     "@actions/workflow-parser": "^0.3.10",
     "vscode-languageserver-textdocument": "^1.0.7",
     "vscode-languageserver-types": "^3.17.2",
-    "vscode-uri": "^3.0.7",
+    "vscode-uri": "^3.0.8",
     "yaml": "^2.1.1"
   },
   "engines": {

--- a/languageservice/src/document-links.ts
+++ b/languageservice/src/document-links.ts
@@ -4,7 +4,7 @@ import {File} from "@actions/workflow-parser/workflows/file";
 import {parseFileReference} from "@actions/workflow-parser/workflows/file-reference";
 import {TextDocument} from "vscode-languageserver-textdocument";
 import {DocumentLink} from "vscode-languageserver-types";
-import vscodeURI from "vscode-uri/lib/umd"; // work around issues with the vscode-uri package
+import * as vscodeURI from "vscode-uri";
 import {actionUrl, parseActionReference} from "./action";
 import {mapRange} from "./utils/range";
 import {fetchOrConvertWorkflowTemplate, fetchOrParseWorkflow} from "./utils/workflow-cache";

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,7 +685,7 @@
         "@actions/workflow-parser": "^0.3.10",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-languageserver-types": "^3.17.2",
-        "vscode-uri": "^3.0.7",
+        "vscode-uri": "^3.0.8",
         "yaml": "^2.1.1"
       },
       "devDependencies": {
@@ -5616,7 +5616,6 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5625,7 +5624,6 @@
     },
     "node_modules/encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10596,7 +10594,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -11502,9 +11500,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-      "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
     },
     "node_modules/walk-up-path": {
       "version": "1.0.0",


### PR DESCRIPTION
In support of [dependabot update](https://github.com/github/vscode-github-actions/pull/337) in the Actions vscode extension. This syntax is supported in subsequent versions of vscode-uri

Tested locally running the extension in workspace mode and confirmed reusable workflows linking still worked as expected.

<img width="968" alt="unable to find reusable workflow message" src="https://github.com/user-attachments/assets/44186791-1ab1-4322-aa67-ad04f9f67993">
<img width="968" alt="reusable workflow linked as expected" src="https://github.com/user-attachments/assets/3f23aa3a-d17b-4d26-8c1f-405d58535888">
