### PR TITLE
Make `jobs.<job_id>.steps` required in `job-factory`

### DIFF
--- a/languageservice/src/validate.test.ts
+++ b/languageservice/src/validate.test.ts
@@ -11,7 +11,9 @@ beforeEach(() => {
 
 describe("validation", () => {
   it("valid workflow", async () => {
-    const result = await validate(createDocument("wf.yaml", "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest"));
+    const result = await validate(
+      createDocument("wf.yaml", "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n    - run: echo")
+    );
 
     expect(result.length).toBe(0);
   });
@@ -144,7 +146,9 @@ jobs:
 jobs:
   build:
     runs-on:
-    - ubuntu-latest`
+    - ubuntu-latest
+    steps:
+    - run: echo hello`
       ),
       {valueProviderConfig: defaultValueProviders}
     );
@@ -174,7 +178,9 @@ jobs:
     - cron: '0 0 * *'
 jobs:
   build:
-    runs-on: ubuntu-latest`
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo hello`
       ),
       {valueProviderConfig: defaultValueProviders}
     );

--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -1700,7 +1700,10 @@
           "concurrency": "job-concurrency",
           "outputs": "job-outputs",
           "defaults": "job-defaults",
-          "steps": "steps"
+          "steps": {
+            "type": "steps",
+            "required": true
+          }
         }
       }
     },

--- a/workflow-parser/testdata/reader/errors-job-runs-on-and-no-steps.yml
+++ b/workflow-parser/testdata/reader/errors-job-runs-on-and-no-steps.yml
@@ -1,0 +1,14 @@
+include-source: false # Drop file/line/col from output
+---
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+---
+{
+  "errors": [
+    {
+      "Message": ".github/workflows/errors-job-runs-on-and-no-steps.yml (Line: 4, Col: 5): Required property is missing: steps"
+    }
+  ]
+}

--- a/workflow-parser/testdata/reader/errors-job-runs-on-and-uses.yml
+++ b/workflow-parser/testdata/reader/errors-job-runs-on-and-uses.yml
@@ -5,6 +5,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     uses: ./.github/workflows/foo.yml
+    steps:
+      - run: echo hello
 ---
 {
   "errors": [


### PR DESCRIPTION
Fixes https://github.com/github/vscode-github-actions/issues/291.

This PR makes `steps` property required by jobs that don't call reusable workflows.

The only non-test change is
```diff
--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -1700,7 +1700,10 @@
           "concurrency": "job-concurrency",
           "outputs": "job-outputs",
           "defaults": "job-defaults",
-          "steps": "steps"
+          "steps": {
+            "type": "steps",
+            "required": true
+          }
         }
       }
     },
```

------

Without `steps`, such jobs won't even run. It's shown in https://github.com/muzimuzhi/hello-github-actions/pull/33 that triggering workflow file
```yaml
on:
  push:
  workflow_dispatch: # optional
jobs:
  no-steps:
    runs-on: ubuntu-latest
```
would fail with
```
Invalid workflow file: .github/workflows/test-github-actions.yml#L1
No steps defined in `steps` and no workflow called in `uses` for the following jobs: no-steps
```
