### PR TITLE
Remove import assertions

### DIFF
--- a/languageservice/script/webhooks/index.ts
+++ b/languageservice/script/webhooks/index.ts
@@ -1,7 +1,7 @@
 import {promises as fs} from "fs";
 import Webhook from "./webhook.js";
 
-import schemaImport from "rest-api-description/descriptions/api.github.com/dereferenced/api.github.com.deref.json" assert {type: "json"};
+import schemaImport from "rest-api-description/descriptions/api.github.com/dereferenced/api.github.com.deref.json";
 import {deduplicateWebhooks} from "./deduplicate.js";
 const schema = schemaImport as any;
 

--- a/languageservice/src/context-providers/descriptions.ts
+++ b/languageservice/src/context-providers/descriptions.ts
@@ -1,4 +1,4 @@
-import descriptions from "./descriptions.json" assert {type: "json"};
+import descriptions from "./descriptions.json";
 
 export const RootContext = "root";
 const FunctionContext = "functions";

--- a/languageservice/src/context-providers/events/eventPayloads.ts
+++ b/languageservice/src/context-providers/events/eventPayloads.ts
@@ -3,8 +3,8 @@ import {data, DescriptionDictionary} from "@actions/expressions";
 import webhookObjects from "./objects.json";
 import webhooks from "./webhooks.json";
 
-import schedule from "./schedule.json" assert {type: "json"};
-import workflow_call from "./workflow_call.json" assert {type: "json"};
+import schedule from "./schedule.json";
+import workflow_call from "./workflow_call.json";
 
 const customEventPayloads: {[name: string]: unknown} = {
   schedule,

--- a/workflow-parser/src/workflows/workflow-schema.ts
+++ b/workflow-parser/src/workflows/workflow-schema.ts
@@ -1,6 +1,6 @@
 import {JSONObjectReader} from "../templates/json-object-reader";
 import {TemplateSchema} from "../templates/schema";
-import WorkflowSchema from "../workflow-v1.0.json" assert {type: "json"};
+import WorkflowSchema from "../workflow-v1.0.json";
 
 let schema: TemplateSchema;
 


### PR DESCRIPTION
This PR removes the import assertions, fixes #144 

They provide limited security benefit in nodejs and the alternative syntax using `with` isn't compatible with the installed versions of typescript and eslint.