### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -1,4 +1,6 @@
 name: Build & Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/actions/languageservices/security/code-scanning/2](https://github.com/actions/languageservices/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with the repository's contents (e.g., checking out code, installing dependencies, and running tests). Therefore, the `contents: read` permission is sufficient. No write permissions are needed.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
