### PR TITLE
Update DEFAULT_RUNNER_LABELS to match current GitHub runners

### DIFF
--- a/languageservice/src/value-providers/default.ts
+++ b/languageservice/src/value-providers/default.ts
@@ -6,17 +6,28 @@ import {stringsToValues} from "./strings-to-values";
 
 export const DEFAULT_RUNNER_LABELS = [
   "ubuntu-latest",
+  "ubuntu-24.04",
   "ubuntu-22.04",
-  "ubuntu-20.04",
-  "ubuntu-18.04",
+  "ubuntu-24.04-arm",
+  "ubuntu-22.04-arm",
   "windows-latest",
+  "windows-2025",
   "windows-2022",
   "windows-2019",
+  "windows-11-arm",
   "macos-latest",
-  "macos-12",
-  "macos-11",
-  "macos-10.15",
-  "self-hosted"
+  "macos-latest-large",
+  "macos-latest-xlarge",
+  "macos-15",
+  "macos-15-large",
+  "macos-15-xlarge",
+  "macos-14",
+  "macos-14-large",
+  "macos-14-xlarge",
+  "macos-13",
+  "macos-13-large",
+  "macos-13-xlarge",
+  "self-hosted",
 ];
 
 export const defaultValueProviders: ValueProviderConfig = {


### PR DESCRIPTION
## Summary

This PR updates the `DEFAULT_RUNNER_LABELS` array to reflect the current GitHub Actions runner support status, improving the VSCode auto-completion experience for workflow authors.

## Changes Made

### Removed unsupported runners:
- `ubuntu-18.04`, `ubuntu-20.04` (support ended April 2025)
- `macos-10.15`, `macos-11`, `macos-12` (support ended)

### Added current runners:
- `ubuntu-22.04` 
- `ubuntu-24.04` 
- `windows-2025`
- `windows-11-arm`
- `macos-13`, `macos-14`, `macos-15`
- ARM variants: `ubuntu-22.04-arm`, `ubuntu-24.04-arm`
- Large runners: `macos-13-large`, `macos-14-large`, `macos-15-large`, `macos-latest-large`
- XLarge runners: `macos-13-xlarge`, `macos-14-xlarge`, `macos-15-xlarge`, `macos-latest-xlarge`

## Validation

I conducted comprehensive validation of all GitHub Actions runners. Full results are available:
- [GitHub Actions Test Results](https://github.com/kfess/gha-syntax-check/actions/runs/14941228853)
- [Detailed Summary](https://github.com/kfess/gha-syntax-check/blob/main/docs/supported-os.md)

## Related Issue

Resolves: #183 

## References

- [GitHub Documentation on Hosted Runners](https://docs.github.com/ja/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners)
- [GitHub Runner Images Repository](https://github.com/actions/runner-images)