### PR TITLE
Fix: correct error handling for non-string keys in YAML validation

### DIFF
--- a/workflow-parser/src/workflows/yaml-object-reader.ts
+++ b/workflow-parser/src/workflows/yaml-object-reader.ts
@@ -77,7 +77,7 @@ export class YamlObjectReader implements ObjectReader {
     if (isPair(node)) {
       const scalarKey = node.key as Scalar;
       range = this.getRange(scalarKey);
-      const key = scalarKey.value as string;
+      const key = scalarKey.value === null ? "" : String(scalarKey.value);
       yield new ParseEvent(EventType.Literal, new StringToken(this.fileId, range, key, undefined));
       for (const child of this.getNodes(node.value)) {
         yield child;


### PR DESCRIPTION
**Description**
This PR fixes the incorrect error messages that appear when YAML files contain non-string keys (numbers, null, boolean values) in the GitHub Actions VSCode extension.
I think the issue is caused by the YAML parser assuming all keys are strings without proper type conversion.

**Changes Made**
- Modified the YAML parser to properly convert all scalar values to strings before processing
- Replaced the type assertion as string with explicit string conversion using String()
- Added special handling for null values to convert them to empty strings, matching the GitHub Actions runner behavior
- Fixed JavaScript errors like i.indexOf is not a function that occurred with numeric keys
- Ensured boolean keys (true/false) are properly stringified

Fix #185 