### PR TITLE
fix: pull_request types miss milestoned and demiletoned

### DIFF
--- a/workflow-parser/testdata/reader/events-mapping-all.yml
+++ b/workflow-parser/testdata/reader/events-mapping-all.yml
@@ -133,6 +133,8 @@ on:
       - review_request_removed
       - auto_merge_enabled
       - auto_merge_disabled
+      - milestoned
+      - demilestoned
   pull_request_comment:
     types:
       - created


### PR DESCRIPTION
refs: 
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request