### PR TITLE
Bump `webpack-dev-server: >=5.2.1`

### DIFF
--- a/browser-playground/package.json
+++ b/browser-playground/package.json
@@ -34,6 +34,6 @@
     "typescript": "^4.9.4",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
-    "webpack-dev-server": "^4.11.1"
+    "webpack-dev-server": ">=5.2.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
         "typescript": "^4.9.4",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
-        "webpack-dev-server": "^4.11.1"
+        "webpack-dev-server": ">=5.2.1"
       }
     },
     "expressions": {


### PR DESCRIPTION
Bump webpack-dev-server to `>=5.2.1` to resolve securty vulnerability issues
- https://github.com/actions/languageservices/security/dependabot/36
- https://github.com/actions/languageservices/security/dependabot/35