### PR TITLE
Add new artifact-metadata permission to schema

### DIFF
--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -1581,6 +1581,7 @@
           "artifact-metadata": {
             "type": "permission-level-any",
             "description": "Storage and deployment records for build artifacts."
+          },
           "attestations": {
             "type": "permission-level-any",
             "description": "Artifact attestations."


### PR DESCRIPTION
Updates `workflow-v1.0.json` with support for the new `artifact_metadata` permission. Follows previous PRs like [attestation permission](https://github.com/actions/languageservices/pull/72) and [models permission](https://github.com/actions/languageservices/pull/175) ✨ 