### PR TITLE
Validate expression block-scalar chomping

### DIFF
--- a/languageservice/src/validate.expressions-chomp-allowed.test.ts
+++ b/languageservice/src/validate.expressions-chomp-allowed.test.ts
@@ -1,0 +1,58 @@
+import {registerLogger} from "./log";
+import {createDocument} from "./test-utils/document";
+import {TestLogger} from "./test-utils/logger";
+import {clearCache} from "./utils/workflow-cache";
+import {validate} from "./validate";
+
+registerLogger(new TestLogger());
+
+beforeEach(() => {
+  clearCache();
+});
+
+describe("block scalar chomping - allowed cases", () => {
+  it("does NOT warn for step.run with clip chomping (exception)", async () => {
+    const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo \${{ github.event_name }}
+`;
+    const result = await validate(createDocument("wf.yaml", input));
+
+    expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+  });
+
+  it("does not warn for inline expression", async () => {
+    const input = `
+on: push
+jobs:
+  build:
+    if: \${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+    const result = await validate(createDocument("wf.yaml", input));
+
+    expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+  });
+
+  it("does not warn for quoted string", async () => {
+    const input = `
+on: push
+jobs:
+  build:
+    if: "\${{ github.event_name == 'push' }}"
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+    const result = await validate(createDocument("wf.yaml", input));
+
+    expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+  });
+});

--- a/languageservice/src/validate.expressions-chomp-error-boolean.test.ts
+++ b/languageservice/src/validate.expressions-chomp-error-boolean.test.ts
@@ -1,0 +1,142 @@
+import {DiagnosticSeverity} from "vscode-languageserver-types";
+import {registerLogger} from "./log";
+import {createDocument} from "./test-utils/document";
+import {TestLogger} from "./test-utils/logger";
+import {clearCache} from "./utils/workflow-cache";
+import {validate} from "./validate";
+
+registerLogger(new TestLogger());
+
+beforeEach(() => {
+  clearCache();
+});
+
+describe("block scalar chomping - boolean fields", () => {
+  describe("job continue-on-error", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: |
+      \${{ matrix.experimental }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: |+
+      \${{ matrix.experimental }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: |-
+      \${{ matrix.experimental }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("step continue-on-error", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        continue-on-error: |
+          \${{ matrix.experimental }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        continue-on-error: |+
+          \${{ matrix.experimental }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        continue-on-error: |-
+          \${{ matrix.experimental }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+});

--- a/languageservice/src/validate.expressions-chomp-error-if.test.ts
+++ b/languageservice/src/validate.expressions-chomp-error-if.test.ts
@@ -1,0 +1,188 @@
+import {DiagnosticSeverity} from "vscode-languageserver-types";
+import {registerLogger} from "./log";
+import {createDocument} from "./test-utils/document";
+import {TestLogger} from "./test-utils/logger";
+import {clearCache} from "./utils/workflow-cache";
+import {validate} from "./validate";
+
+registerLogger(new TestLogger());
+
+beforeEach(() => {
+  clearCache();
+});
+
+describe("block scalar chomping - if fields", () => {
+  describe("job-if", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    if: |
+      \${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    if: |+
+      \${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    if: |-
+      \${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+
+    it("errors without ${{ }} (isExpression)", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    if: |
+      github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("uses > indicator in error message for folded scalars", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    if: >
+      \${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '>-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+  });
+
+  describe("step-if", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: |
+          \${{ github.event_name == 'push' }}
+        run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: |+
+          \${{ github.event_name == 'push' }}
+        run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: |-
+          \${{ github.event_name == 'push' }}
+        run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+});

--- a/languageservice/src/validate.expressions-chomp-error-number.test.ts
+++ b/languageservice/src/validate.expressions-chomp-error-number.test.ts
@@ -1,0 +1,428 @@
+import {DiagnosticSeverity} from "vscode-languageserver-types";
+import {registerLogger} from "./log";
+import {createDocument} from "./test-utils/document";
+import {TestLogger} from "./test-utils/logger";
+import {clearCache} from "./utils/workflow-cache";
+import {validate} from "./validate";
+
+registerLogger(new TestLogger());
+
+beforeEach(() => {
+  clearCache();
+});
+
+describe("block scalar chomping - number fields", () => {
+  describe("job timeout-minutes", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: |
+      \${{ matrix.timeout }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: |+
+      \${{ matrix.timeout }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: |-
+      \${{ matrix.timeout }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("container.ports", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      ports: |
+        \${{ fromJSON('[80, 443]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      ports: |+
+        \${{ fromJSON('[8080, 9090]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      ports: |-
+        \${{ fromJSON('[80, 443]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("container.volumes", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      volumes: |
+        \${{ fromJSON('["/data:/data"]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      volumes: |+
+        \${{ fromJSON('["/data:/data"]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      volumes: |-
+        \${{ fromJSON('["/data:/data"]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("services.ports", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        ports: |
+          \${{ fromJSON('[5432]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        ports: |+
+          \${{ fromJSON('[5432]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        ports: |-
+          \${{ fromJSON('[5432]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("services.volumes", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        volumes: |
+          \${{ fromJSON('["/var/lib/postgresql/data"]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        volumes: |+
+          \${{ fromJSON('["/var/lib/postgresql/data"]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        volumes: |-
+          \${{ fromJSON('["/var/lib/postgresql/data"]') }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("step timeout-minutes", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        timeout-minutes: |
+          \${{ matrix.timeout }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        timeout-minutes: |+
+          \${{ matrix.timeout }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message:
+            "Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        timeout-minutes: |-
+          \${{ matrix.timeout }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+});

--- a/languageservice/src/validate.expressions-chomp-error-string.test.ts
+++ b/languageservice/src/validate.expressions-chomp-error-string.test.ts
@@ -1,0 +1,1361 @@
+import {DiagnosticSeverity} from "vscode-languageserver-types";
+import {registerLogger} from "./log";
+import {createDocument} from "./test-utils/document";
+import {TestLogger} from "./test-utils/logger";
+import {clearCache} from "./utils/workflow-cache";
+import {validate} from "./validate";
+
+registerLogger(new TestLogger());
+
+beforeEach(() => {
+  clearCache();
+});
+
+describe("block scalar chomping - string fields", () => {
+  describe("run-name", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+run-name: |
+  Test \${{ github.event_name }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+run-name: |+
+  Test \${{ github.event_name }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+run-name: |-
+  Test \${{ github.event_name }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("job name", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: |
+      Build \${{ matrix.name }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: |+
+      Build \${{ matrix.name }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: |-
+      Build \${{ matrix.name }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("workflow job name", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/reusable.yml
+    name: |
+      Call \${{ matrix.name }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/reusable.yml
+    name: |+
+      Call \${{ matrix.name }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  call-workflow:
+    uses: ./.github/workflows/reusable.yml
+    name: |-
+      Call \${{ matrix.name }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("container (string form)", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: |
+      \${{ matrix.container }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: |+
+      \${{ matrix.container }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: |-
+      \${{ matrix.container }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("container.image", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: |
+        \${{ matrix.container }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: |+
+        \${{ matrix.image }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: |-
+        \${{ matrix.image }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("container.credentials", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      credentials: |
+        \${{ secrets.DOCKER_TOKEN }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      credentials: |+
+        \${{ secrets.DOCKER_TOKEN }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+      credentials: |-
+        \${{ secrets.DOCKER_TOKEN }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("job defaults.run.shell", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: |
+          \${{ matrix.shell }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: |+
+          \${{ matrix.shell }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: |-
+          \${{ matrix.shell }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("job defaults.run.working-directory", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: |
+          \${{ matrix.dir }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: |+
+          \${{ matrix.dir }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: |-
+          \${{ matrix.dir }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("job environment (string form)", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: |
+      \${{ matrix.env }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: |+
+      \${{ matrix.env }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: |-
+      \${{ matrix.env }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("job environment.name", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: |
+        \${{ matrix.env }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: |+
+        \${{ matrix.env }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: |-
+        \${{ matrix.env }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("job environment.url", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: |
+        \${{ steps.deploy.outputs.url }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: |+
+        \${{ steps.deploy.outputs.url }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: |-
+        \${{ steps.deploy.outputs.url }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("services (string form)", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      redis: |
+        \${{ matrix.redis-image }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      redis: |+
+        \${{ matrix.redis-image }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      redis: |-
+        \${{ matrix.redis-image }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("services.image", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: |
+          \${{ matrix.postgres-version }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: |+
+          \${{ matrix.postgres-version }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: |-
+          \${{ matrix.postgres-version }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("services.credentials", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        credentials: |
+          \${{ secrets.DOCKER_CREDS }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        credentials: |+
+          \${{ secrets.DOCKER_CREDS }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        credentials: |-
+          \${{ secrets.DOCKER_CREDS }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("runs-on (string form)", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: |
+      \${{ matrix.os }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: |+
+      \${{ matrix.os }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: |-
+      \${{ matrix.os }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("runs-on array item", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      - |
+        \${{ matrix.os }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      - |+
+        \${{ matrix.os }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      - |-
+        \${{ matrix.os }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("runs-on.group", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      group: |
+        \${{ matrix.runner-group }}
+      labels: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      group: |+
+        \${{ matrix.runner-group }}
+      labels: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      group: |-
+        \${{ matrix.runner-group }}
+      labels: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("runs-on.labels (string form)", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      labels: |
+        \${{ matrix.labels }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      labels: |+
+        \${{ matrix.labels }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      labels: |-
+        \${{ matrix.labels }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("runs-on.labels array item", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      labels:
+        - |
+          \${{ matrix.label }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      labels:
+        - |+
+          \${{ matrix.label }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on:
+      labels:
+        - |-
+          \${{ matrix.label }}
+    steps:
+      - run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("step name", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: |
+          Test \${{ matrix.name }}
+        run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: |+
+          Test \${{ matrix.name }}
+        run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: |-
+          Test \${{ matrix.name }}
+        run: echo hi
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+
+  describe("step working-directory", () => {
+    it("errors with clip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        working-directory: |
+          \${{ matrix.dir }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("errors with keep chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        working-directory: |+
+          \${{ matrix.dir }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          message: "Block scalar adds trailing newline. Use '|-' to strip trailing newlines.",
+          code: "expression-block-scalar-chomping",
+          severity: DiagnosticSeverity.Error
+        })
+      );
+    });
+
+    it("does not error with strip chomping", async () => {
+      const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        working-directory: |-
+          \${{ matrix.dir }}
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+
+      expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+    });
+  });
+});

--- a/languageservice/src/validate.expressions-chomp-warning.test.ts
+++ b/languageservice/src/validate.expressions-chomp-warning.test.ts
@@ -1,0 +1,227 @@
+import {DiagnosticSeverity} from "vscode-languageserver-types";
+import {registerLogger} from "./log";
+import {createDocument} from "./test-utils/document";
+import {TestLogger} from "./test-utils/logger";
+import {clearCache} from "./utils/workflow-cache";
+import {validate} from "./validate";
+
+registerLogger(new TestLogger());
+
+beforeEach(() => {
+  clearCache();
+});
+
+describe("expression validation", () => {
+  describe("block scalar chomping - fields that warn only for clip", () => {
+    describe("env", () => {
+      it("warns with clip chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo $VAR
+        env:
+          VAR: |
+            \${{ matrix.value }}
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result).toContainEqual(
+          expect.objectContaining({
+            message:
+              "Block scalar adds trailing newline to expression result. Use '|-' to strip or '|+' to keep trailing newlines.",
+            code: "expression-block-scalar-chomping",
+            severity: DiagnosticSeverity.Warning
+          })
+        );
+      });
+
+      it("does not warn with keep chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo $VAR
+        env:
+          VAR: |+
+            \${{ matrix.value }}
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+      });
+
+      it("does not warn with strip chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo $VAR
+        env:
+          VAR: |-
+            \${{ matrix.value }}
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+      });
+
+      it("uses > indicator in warning message for folded scalars", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo $VAR
+        env:
+          VAR: >
+            \${{ matrix.value }}
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result).toContainEqual(
+          expect.objectContaining({
+            message:
+              "Block scalar adds trailing newline to expression result. Use '>-' to strip or '>+' to keep trailing newlines.",
+            code: "expression-block-scalar-chomping",
+            severity: DiagnosticSeverity.Warning
+          })
+        );
+      });
+    });
+
+    describe("action input", () => {
+      it("warns with clip chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: |
+            \${{ github.ref }}
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result).toContainEqual(
+          expect.objectContaining({
+            message:
+              "Block scalar adds trailing newline to expression result. Use '|-' to strip or '|+' to keep trailing newlines.",
+            code: "expression-block-scalar-chomping",
+            severity: DiagnosticSeverity.Warning
+          })
+        );
+      });
+
+      it("does not warn with keep chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: |+
+            \${{ github.ref }}
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+      });
+
+      it("does not warn with strip chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: |-
+            \${{ github.ref }}
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+      });
+    });
+
+    describe("matrix value", () => {
+      it("warns with clip chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: |
+          \${{ fromJSON('[1, 2, 3]') }}
+    steps:
+      - run: echo hi
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result).toContainEqual(
+          expect.objectContaining({
+            message:
+              "Block scalar adds trailing newline to expression result. Use '|-' to strip or '|+' to keep trailing newlines.",
+            code: "expression-block-scalar-chomping",
+            severity: DiagnosticSeverity.Warning
+          })
+        );
+      });
+
+      it("does not warn with keep chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: |+
+          \${{ fromJSON('[1, 2, 3]') }}
+    steps:
+      - run: echo hi
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+      });
+
+      it("does not warn with strip chomping", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: |-
+          \${{ fromJSON('[1, 2, 3]') }}
+    steps:
+      - run: echo hi
+`;
+        const result = await validate(createDocument("wf.yaml", input));
+
+        expect(result.filter(d => d.code === "expression-block-scalar-chomping")).toEqual([]);
+      });
+    });
+  });
+});

--- a/workflow-parser/src/expressions.test.ts
+++ b/workflow-parser/src/expressions.test.ts
@@ -200,4 +200,284 @@ jobs:
       throw new Error("expected if to be a basic expression");
     }
   });
+
+  describe("Block scalar chomp style preservation", () => {
+    it("preserves clip chomping (|) for literal block scalar", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: |
+      \${{ github.event_name == 'push' }}
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBe("BLOCK_LITERAL");
+      expect(ifToken.chompStyle).toBe("clip");
+    });
+
+    it("preserves strip chomping (|-) for literal block scalar", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: |-
+      \${{ github.event_name == 'push' }}
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBe("BLOCK_LITERAL");
+      expect(ifToken.chompStyle).toBe("strip");
+    });
+
+    it("preserves keep chomping (|+) for literal block scalar", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: |+
+      \${{ github.event_name == 'push' }}
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBe("BLOCK_LITERAL");
+      expect(ifToken.chompStyle).toBe("keep");
+    });
+
+    it("preserves folded clip (>) chomping", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: >
+      \${{ github.event_name == 'push' }}
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBe("BLOCK_FOLDED");
+      expect(ifToken.chompStyle).toBe("clip");
+    });
+
+    it("preserves folded strip (>-) chomping", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: >-
+      \${{ github.event_name == 'push' }}
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBe("BLOCK_FOLDED");
+      expect(ifToken.chompStyle).toBe("strip");
+    });
+
+    it("preserves with explicit indent (|2)", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: |2
+      \${{ github.event_name == 'push' }}
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBe("BLOCK_LITERAL");
+      expect(ifToken.chompStyle).toBe("clip");
+    });
+
+    it("preserves with explicit indent and strip (|-2)", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: |-2
+      \${{ github.event_name == 'push' }}
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBe("BLOCK_LITERAL");
+      expect(ifToken.chompStyle).toBe("strip");
+    });
+
+    it("handles flow scalars (no chomp info for inline)", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: \${{ github.event_name == 'push' }}
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBeUndefined();
+      expect(ifToken.chompStyle).toBeUndefined();
+    });
+
+    it("handles job-if without ${{ }} (isExpression case)", () => {
+      const result = parseWorkflow(
+        {
+          name: "test.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'push'
+    steps:
+      - run: echo hi`
+        },
+        nullTrace
+      );
+
+      expect(result.context.errors.getErrors()).toHaveLength(0);
+
+      const workflowRoot = result.value!.assertMapping("root")!;
+      const jobs = workflowRoot.get(1).value.assertMapping("jobs");
+      const build = jobs.get(0).value.assertMapping("job");
+      const ifToken = build.get(1).value;
+
+      if (!isBasicExpression(ifToken)) {
+        throw new Error("expected if to be a basic expression");
+      }
+
+      expect(ifToken.scalarType).toBe("BLOCK_LITERAL");
+      expect(ifToken.chompStyle).toBe("clip");
+    });
+  });
 });

--- a/workflow-parser/src/templates/tokens/basic-expression-token.ts
+++ b/workflow-parser/src/templates/tokens/basic-expression-token.ts
@@ -1,3 +1,4 @@
+import {Scalar} from "yaml";
 import {DefinitionInfo} from "../schema/definition-info";
 
 import {CLOSE_EXPRESSION, OPEN_EXPRESSION} from "../template-constants";
@@ -24,6 +25,16 @@ export class BasicExpressionToken extends ExpressionToken {
   public readonly expressionRange: TokenRange | undefined;
 
   /**
+   * The YAML scalar type (e.g., BLOCK_LITERAL, BLOCK_FOLDED, PLAIN, etc.) if the expression was parsed from a block scalar.
+   */
+  public readonly scalarType: Scalar.Type | undefined;
+
+  /**
+   * The chomp style of the block scalar: 'clip' (default, keeps one newline), 'strip' (removes all), or 'keep' (keeps all).
+   */
+  public readonly chompStyle: "clip" | "strip" | "keep" | undefined;
+
+  /**
    * @param originalExpressions If the basic expression was transformed from individual expressions, these will be the original ones
    */
   public constructor(
@@ -33,13 +44,17 @@ export class BasicExpressionToken extends ExpressionToken {
     definitionInfo: DefinitionInfo | undefined,
     originalExpressions: BasicExpressionToken[] | undefined,
     source: string | undefined,
-    expressionRange?: TokenRange | undefined
+    expressionRange?: TokenRange | undefined,
+    scalarType?: Scalar.Type | undefined,
+    chompStyle?: "clip" | "strip" | "keep" | undefined
   ) {
     super(TokenType.BasicExpression, file, range, undefined, definitionInfo);
     this.expr = expression;
     this.source = source;
     this.originalExpressions = originalExpressions;
     this.expressionRange = expressionRange;
+    this.scalarType = scalarType;
+    this.chompStyle = chompStyle;
   }
 
   public get expression(): string {
@@ -55,7 +70,9 @@ export class BasicExpressionToken extends ExpressionToken {
           this.definitionInfo,
           this.originalExpressions,
           this.source,
-          this.expressionRange
+          this.expressionRange,
+          this.scalarType,
+          this.chompStyle
         )
       : new BasicExpressionToken(
           this.file,
@@ -64,7 +81,9 @@ export class BasicExpressionToken extends ExpressionToken {
           this.definitionInfo,
           this.originalExpressions,
           this.source,
-          this.expressionRange
+          this.expressionRange,
+          this.scalarType,
+          this.chompStyle
         );
   }
 

--- a/workflow-parser/src/templates/tokens/string-token.ts
+++ b/workflow-parser/src/templates/tokens/string-token.ts
@@ -1,3 +1,4 @@
+import {Scalar} from "yaml";
 import {LiteralToken, TemplateToken} from ".";
 import {DefinitionInfo} from "../schema/definition-info";
 import {TokenRange} from "./token-range";
@@ -6,23 +7,45 @@ import {TokenType} from "./types";
 export class StringToken extends LiteralToken {
   public readonly value: string;
   public readonly source: string | undefined;
+  public readonly scalarType: Scalar.Type | undefined;
+  public readonly blockScalarHeader: string | undefined;
 
   public constructor(
     file: number | undefined,
     range: TokenRange | undefined,
     value: string,
     definitionInfo: DefinitionInfo | undefined,
-    source?: string
+    source?: string,
+    scalarType?: Scalar.Type,
+    blockScalarHeader?: string
   ) {
     super(TokenType.String, file, range, definitionInfo);
     this.value = value;
     this.source = source;
+    this.scalarType = scalarType;
+    this.blockScalarHeader = blockScalarHeader;
   }
 
   public override clone(omitSource?: boolean): TemplateToken {
     return omitSource
-      ? new StringToken(undefined, undefined, this.value, this.definitionInfo, this.source)
-      : new StringToken(this.file, this.range, this.value, this.definitionInfo, this.source);
+      ? new StringToken(
+          undefined,
+          undefined,
+          this.value,
+          this.definitionInfo,
+          this.source,
+          this.scalarType,
+          this.blockScalarHeader
+        )
+      : new StringToken(
+          this.file,
+          this.range,
+          this.value,
+          this.definitionInfo,
+          this.source,
+          this.scalarType,
+          this.blockScalarHeader
+        );
   }
 
   public override toString(): string {


### PR DESCRIPTION
## Summary

Adds validation for multi-line expressions. Block scalars (`|` and `>`) add trailing newlines by default, which can cause unintentional expression results.

In fields where trailing newlines don't make sense (booleans, numbers, and many strings), the validation produces an **error**:

**Boolean:**
```yaml
jobs:
  test:
    if: |                # ❌ Error: Block scalar adds trailing newline which breaks boolean evaluation. Use '|-' to strip trailing newlines.
      ${{ github.event_name == 'push' }}
    if: |-               # ✅ OK
      ${{ github.event_name == 'push' }}
```

**Number:**
```yaml
jobs:
  test:
    timeout-minutes: |   # ❌ Error: Block scalar adds trailing newline which breaks number parsing. Use '|-' to strip trailing newlines.
      ${{ fromJSON(vars.TIMEOUT) }}
    timeout-minutes: |-  # ✅ OK
      ${{ fromJSON(vars.TIMEOUT) }}
```

**String:**
```yaml
jobs:
  test:
    runs-on: |           # ❌ Error: Block scalar adds trailing newline. Use '|-' to strip trailing newlines.
      ${{ matrix.os }}
    runs-on: |-          # ✅ OK
      ${{ matrix.os }}
```

In other fields where newlines are unlikely, a **warning** is produced:

```yaml
steps:
  - uses: actions/checkout@v4
    with:
      token: |           # ⚠️ Warning: Block scalar adds trailing newline to expression result. Use '|-' to strip or '|+' to keep trailing newlines.
        ${{ secrets.PAT }}
```

The `run` step is the exception to the rule, since trailing newlines don't matter:

```yaml
steps:
  - run: |               # ✅ OK: trailing newlines don't matter
      echo "Commit: ${{ github.sha }}"
```

## Testing

Added comprehensive test coverage across 6 test files organized by severity and field type:

- **Error** - Job and step `if` fields. Special because this is the only place `${{ }}` is optional.
- **Error** - Boolean fields, e.g. `continue-on-error`
- **Error** - Number fields, e.g. `timeout-minutes`, `ports`, `volumes`
- **Error** - String fields, e.g. `name`, `runs-on`, `container`, `environment`
- **Warning fields** - Action inputs, reusable workflow inputs, etc
- **Allowed** - Only `run`

Each test validates behavior across different chomping indicators - e.g. `|`, `|-`, `|+`, `>`, etc.