### PR TITLE
Improve cron schedule warning message

### DIFF
--- a/languageservice/src/validate.test.ts
+++ b/languageservice/src/validate.test.ts
@@ -211,7 +211,8 @@ jobs:
 
     expect(result.length).toBe(1);
     expect(result[0]).toEqual({
-      message: "Runs every minute. Note: Actions schedules run at most every 5 minutes.",
+      message:
+        'Actions schedules run at most every 5 minutes. "*/1 * * * *" (runs every minute) will not run as frequently as specified.',
       severity: DiagnosticSeverity.Warning,
       code: "on-schedule",
       codeDescription: {
@@ -281,7 +282,7 @@ jobs:
 
     expect(result.length).toBe(1);
     expect(result[0]?.severity).toBe(DiagnosticSeverity.Warning);
-    expect(result[0]?.message).toContain("Note: Actions schedules run at most every 5 minutes.");
+    expect(result[0]?.message).toContain("Actions schedules run at most every 5 minutes.");
   });
 
   it("invalid YAML", async () => {

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -247,7 +247,7 @@ function validateCronExpression(diagnostics: Diagnostic[], token: StringToken): 
   // Check if the cron specifies an interval less than 5 minutes
   if (hasCronIntervalLessThan5Minutes(cronValue)) {
     diagnostics.push({
-      message: `${description}. Note: Actions schedules run at most every 5 minutes.`,
+      message: `Actions schedules run at most every 5 minutes. "${cronValue}" (${description.toLowerCase()}) will not run as frequently as specified.`,
       range: mapRange(token.range),
       severity: DiagnosticSeverity.Warning,
       code: "on-schedule",


### PR DESCRIPTION
Rewords the warning shown when a cron schedule specifies an interval less than 5 minutes.

Before:

```
Runs every minute. Note: Actions schedules run at most every 5 minutes.
```

After:

```
Actions schedules run at most every 5 minutes. "*/1 * * * *" (runs every minute) will not run as frequently as specified.
```

The new format leads with the constraint and clarifies that the schedule won't behave as expected.