### PR TITLE
Add validation for concurrency deadlock detection

### DIFF
--- a/languageservice/src/validate.concurrency.test.ts
+++ b/languageservice/src/validate.concurrency.test.ts
@@ -1,0 +1,245 @@
+import {DiagnosticSeverity} from "vscode-languageserver-types";
+import {validate} from "./validate";
+import {createDocument} from "./test-utils/document";
+import {clearCache} from "./utils/workflow-cache";
+
+beforeEach(() => {
+  clearCache();
+});
+
+describe("validate concurrency deadlock", () => {
+  describe("should error on matching concurrency groups", () => {
+    it("simple string match", async () => {
+      const input = `
+on: push
+concurrency: test
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency: test
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(2);
+
+      // Workflow-level warning
+      expect(concurrencyErrors[0]).toMatchObject({
+        message: "Concurrency group 'test' is also used by job 'job1'. This will cause a deadlock.",
+        severity: DiagnosticSeverity.Error
+      });
+
+      // Job-level warning
+      expect(concurrencyErrors[1]).toMatchObject({
+        message: "Concurrency group 'test' is also defined at the workflow level. This will cause a deadlock.",
+        severity: DiagnosticSeverity.Error
+      });
+    });
+
+    it("workflow mapping form, job string form", async () => {
+      const input = `
+on: push
+concurrency:
+  group: my-group
+  cancel-in-progress: true
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency: my-group
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(2);
+      expect(concurrencyErrors[0].message).toContain("my-group");
+      expect(concurrencyErrors[0].message).toContain("deploy");
+    });
+
+    it("workflow string form, job mapping form", async () => {
+      const input = `
+on: push
+concurrency: deploy-group
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-group
+      cancel-in-progress: true
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(2);
+      expect(concurrencyErrors[0].message).toContain("deploy-group");
+    });
+
+    it("both mapping forms", async () => {
+      const input = `
+on: push
+concurrency:
+  group: shared
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: shared
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(2);
+    });
+
+    it("multiple jobs with matching concurrency", async () => {
+      const input = `
+on: push
+concurrency: shared
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency: shared
+    steps:
+      - run: echo hi
+  job2:
+    runs-on: ubuntu-latest
+    concurrency: shared
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      // Should have 2 warnings per job (workflow + job) = 4 total, but workflow is only warned once per match
+      // Actually: 1 workflow warning per matching job + 1 job warning per matching job = 4 total
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(4);
+    });
+  });
+
+  describe("should not warn", () => {
+    it("different concurrency groups", async () => {
+      const input = `
+on: push
+concurrency: workflow-group
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency: job-group
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(0);
+    });
+
+    it("workflow concurrency is an expression", async () => {
+      const input = `
+on: push
+concurrency: \${{ github.ref }}
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency: test
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(0);
+    });
+
+    it("job concurrency is an expression", async () => {
+      const input = `
+on: push
+concurrency: test
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency: \${{ github.ref }}
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(0);
+    });
+
+    it("no workflow-level concurrency", async () => {
+      const input = `
+on: push
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency: test
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(0);
+    });
+
+    it("no job-level concurrency", async () => {
+      const input = `
+on: push
+concurrency: test
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(0);
+    });
+
+    it("case sensitive - different case is different group", async () => {
+      const input = `
+on: push
+concurrency: Test
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency: test
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(0);
+    });
+
+    it("workflow concurrency group in mapping is an expression", async () => {
+      const input = `
+on: push
+concurrency:
+  group: \${{ github.ref }}
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency: test
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
+      expect(concurrencyErrors).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes:
- https://github.com/github/vscode-github-actions/issues/135

## Summary

Adds an error when workflow-level and job-level concurrency groups match, which causes a deadlock at runtime. The job blocks waiting for the workflow to finish, while the workflow waits for the job to finish.

## Problem

When a workflow defines the same concurrency group at both levels:

```yaml
on: push
concurrency: deploy
jobs:
  build:
    runs-on: ubuntu-latest
    concurrency: deploy
    steps:
      - run: echo hi
```

GitHub Actions fails with:
```
Canceling since a deadlock was detected for concurrency group: 'deploy' between a top level workflow and 'build'
```

The language service shows **no error** for this invalid configuration.

## Solution

Add `validateConcurrencyDeadlock()` that compares workflow-level and job-level concurrency groups and errors when they match.

**Errors when:**
- Workflow-level concurrency group matches any job-level concurrency group
- Both string form (`concurrency: 'group'`) and mapping form (`concurrency: { group: 'name' }`) are supported

**Does NOT warn when:**
- Either concurrency uses an expression (e.g., `${{ github.ref }}`) - expressions may evaluate to different values
- Groups are different (case-sensitive comparison)
- Only workflow-level or only job-level concurrency is defined

## Error Messages

Two errors are produced (one at each location):

1. **Workflow-level**: `Concurrency group 'deploy' is also used by job 'build'. This will cause a deadlock.`
2. **Job-level**: `Concurrency group 'deploy' is also defined at the workflow level. This will cause a deadlock.`

## Changes

- `languageservice/src/validate.ts`: Added `validateConcurrencyDeadlock()` and `getStaticConcurrencyGroup()` helper
- `languageservice/src/validate.concurrency.test.ts`: New test file with 12 test cases

## Testing

- All 404 languageservice tests pass
- New tests cover:
  - Simple string match
  - Mixed string/mapping forms  
  - Multiple jobs with matching concurrency
  - Different groups (no warning)
  - Expression usage (no warning)
  - Case sensitivity
  - Missing concurrency at either level
