### PR TITLE
Add missing runner context properties (environment, debug, workspace)

### DIFF
--- a/languageservice/src/complete.expressions.test.ts
+++ b/languageservice/src/complete.expressions.test.ts
@@ -299,7 +299,16 @@ jobs:
         "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    environment:\n      url: ${{ runner.| }}\n    steps:\n      - run: echo";
       const result = await complete(...getPositionFromCursor(input), {contextProviderConfig});
 
-      expect(result.map(x => x.label)).toEqual(["arch", "name", "os", "temp", "tool_cache"]);
+      expect(result.map(x => x.label)).toEqual([
+        "arch",
+        "debug",
+        "environment",
+        "name",
+        "os",
+        "temp",
+        "tool_cache",
+        "workspace"
+      ]);
     });
 
     describe("job if", () => {

--- a/languageservice/src/context-providers/default.ts
+++ b/languageservice/src/context-providers/default.ts
@@ -74,11 +74,14 @@ function getDefaultContext(name: string, workflowContext: WorkflowContext, mode:
 
     case "runner":
       return objectToDictionary({
-        os: "Linux",
         arch: "X64",
+        debug: "1",
+        environment: "github-hosted",
         name: "GitHub Actions 2",
+        os: "Linux",
+        temp: "/home/runner/work/_temp",
         tool_cache: "/opt/hostedtoolcache",
-        temp: "/home/runner/work/_temp"
+        workspace: "/home/runner/work/repo"
       });
 
     case "secrets":

--- a/languageservice/src/context-providers/descriptions.json
+++ b/languageservice/src/context-providers/descriptions.json
@@ -239,7 +239,13 @@
       "description": "The path to the directory containing preinstalled tools for GitHub-hosted runners. For more information, see \"[About GitHub-hosted runners](https://docs.github.com/actions/reference/specifications-for-github-hosted-runners/#supported-software).\""
     },
     "debug": {
-      "description": "This is set only if [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) is enabled, and always has the value of `1`. It can be useful as an indicator to enable additional debugging or verbose logging in your own job steps."
+      "description": "This is set only if [`ACTIONS_STEP_DEBUG`](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) is enabled, and always has the value of `\"1\"`. It can be useful as an indicator to enable additional debugging or verbose logging in your own job steps."
+    },
+    "environment": {
+      "description": "The environment of the runner executing the job. Possible values are `github-hosted` for GitHub-hosted runners, or `self-hosted` for self-hosted runners."
+    },
+    "workspace": {
+      "description": "The runner-specific working directory path for the job."
     }
   },
   "strategy": {

--- a/languageservice/src/validate.expressions.test.ts
+++ b/languageservice/src/validate.expressions.test.ts
@@ -1609,6 +1609,48 @@ jobs:
         expect(result).toEqual([]);
       });
 
+      it("allows runner.environment context", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: runner.environment == 'github-hosted'
+        run: echo hello`;
+
+        const result = await validate(createDocument("wf.yaml", input));
+        expect(result).toEqual([]);
+      });
+
+      it("allows runner.debug context", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: runner.debug == '1'
+        run: echo hello`;
+
+        const result = await validate(createDocument("wf.yaml", input));
+        expect(result).toEqual([]);
+      });
+
+      it("allows runner.workspace context", async () => {
+        const input = `
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: runner.workspace != ''
+        run: echo hello`;
+
+        const result = await validate(createDocument("wf.yaml", input));
+        expect(result).toEqual([]);
+      });
+
       it("allows env context", async () => {
         const input = `
 on: push


### PR DESCRIPTION
Fixes:
- https://github.com/actions/languageservices/issues/78
- https://github.com/actions/languageservices/issues/121

Adds three missing properties to the runner context:

| Name | Description |
| --- | --- |
| `runner.environment` | The runner environment (github-hosted or self-hosted) |
| `runner.debug` | Set to '"1"' when step debug logging is enabled via ACTIONS_STEP_DEBUG |
| `runner.workspace` | The runner-specific working directory path for the job |
