### PR TITLE
Allow empty strings in workflow_dispatch choice options

### DIFF
--- a/languageservice/src/validate.test.ts
+++ b/languageservice/src/validate.test.ts
@@ -385,4 +385,31 @@ jobs:
       expect(result).toEqual([]);
     });
   });
+
+  describe("workflow_dispatch", () => {
+    it("allows empty string in choice options", async () => {
+      const result = await validate(
+        createDocument(
+          "wf.yaml",
+          `on:
+  workflow_dispatch:
+    inputs:
+      plugin-name:
+        description: Specific plugin to build
+        type: choice
+        options:
+          - ''
+          - foo
+          - bar
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo`
+        )
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -1539,7 +1539,7 @@
           },
           "default": "workflow-dispatch-input-default",
           "options": {
-            "type": "sequence-of-non-empty-string",
+            "type": "sequence-of-string",
             "description": "The options of the dropdown list, if the type is a choice."
           }
         }
@@ -2417,6 +2417,11 @@
     "sequence-of-non-empty-string": {
       "sequence": {
         "item-type": "non-empty-string"
+      }
+    },
+    "sequence-of-string": {
+      "sequence": {
+        "item-type": "string"
       }
     },
     "boolean-needs-context": {


### PR DESCRIPTION
Fixes:
- https://github.com/github/vscode-github-actions/issues/395

## Summary

Empty strings are valid options for `workflow_dispatch` inputs with `type: choice`.

**Verified on GitHub.com:** Tested that workflows with empty string choice options run successfully.

## Example

```yaml
on:
  workflow_dispatch:
    inputs:
      plugin-name:
        type: choice
        options:
          - ''      # ← Was incorrectly flagged as "Unexpected value ''"
          - foo
          - bar
```

## Changes

- Add `sequence-of-string` type that allows empty strings (unlike `sequence-of-non-empty-string`)
- Use `sequence-of-string` for the `workflow_dispatch` options field
- Add test to verify empty string in choice options doesn't produce validation errors