### PR TITLE
Remove deprecated runner label ubuntu-20.04

### DIFF
--- a/languageservice/src/value-providers/default.ts
+++ b/languageservice/src/value-providers/default.ts
@@ -8,7 +8,6 @@ export const DEFAULT_RUNNER_LABELS = [
   "ubuntu-latest",
   "ubuntu-24.04",
   "ubuntu-22.04",
-  "ubuntu-20.04",
   "ubuntu-slim",
   "windows-latest",
   "windows-2022",


### PR DESCRIPTION
See https://github.com/actions/runner-images?tab=readme-ov-file#available-images.

Follow-up to
- #256

Related issue:
- https://github.com/actions/languageservices/issues/255