### PR TITLE
Fix one-of property completions to insert value on next line

### DIFF
--- a/languageservice/src/value-providers/definition.ts
+++ b/languageservice/src/value-providers/definition.ts
@@ -92,10 +92,10 @@ function mappingValues(
             break;
 
           case DefinitionType.OneOf:
-            if (mode == DefinitionValueMode.Parent) {
-              insertText = `${key}: `;
+            if (mode == DefinitionValueMode.Key) {
+              insertText = `\n${indentation}${key}: `;
             } else {
-              // No special insertText in this case
+              insertText = `${key}: `;
             }
             break;
 


### PR DESCRIPTION
## Current behavior

When completing a property after a colon on the same line, the completion inserts the value directly after the colon:

```yaml
on:
  check_run: ty|   # cursor here, complete `types`
```

Result:

```yaml
on:
  check_run: types  # invalid
```

This works fine for scalar values, but for properties like `types` that expect a nested mapping, this produces invalid YAML.

## Fix

For properties with one-of types (which expand to nested mappings), insert the value on the next line with proper indentation:

```yaml
on:
  check_run:
    types: 
```

This ensures the completion produces valid YAML structure that the user can continue editing.

## Example: permissions

The `permissions` key demonstrates both behaviors working together. When typing `permissions: |`, completions include:

| Selection | Insert text | Result |
|-----------|-------------|--------|
| `read-all` | `read-all` | `permissions: read-all` (scalar value) |
| `actions` | `\n  actions: ` | `permissions:\n  actions: ` (nested mapping) |

String values insert directly, while mapping keys insert on the next line.
