### PR TITLE
Use detail field for one-of qualifiers instead of label

### DIFF
--- a/languageservice/src/complete.ts
+++ b/languageservice/src/complete.ts
@@ -129,6 +129,7 @@ export async function complete(
 
     const item: CompletionItem = {
       label: value.label,
+      detail: value.detail,
       filterText: value.filterText,
       sortText: value.sortText,
       documentation: value.description && {

--- a/languageservice/src/e2e.test.ts
+++ b/languageservice/src/e2e.test.ts
@@ -22,8 +22,8 @@ describe("end-to-end", () => {
 
     expect(result).not.toBeUndefined();
     expect(result.length).toEqual(13);
-    const labels = result.map(x => x.label);
-    expect(labels).toEqual([
+    const labelsWithDetails = result.map(x => (x.detail ? `${x.label} (${x.detail})` : x.label));
+    expect(labelsWithDetails).toEqual([
       "concurrency",
       "concurrency (full syntax)",
       "defaults",

--- a/languageservice/src/value-providers/config.ts
+++ b/languageservice/src/value-providers/config.ts
@@ -7,6 +7,9 @@ export interface Value {
   /** Optional description to show when auto-completing */
   description?: string;
 
+  /** Optional detail shown after the label, e.g. type or kind information */
+  detail?: string;
+
   /** Whether this value is deprecated */
   deprecated?: boolean;
 

--- a/languageservice/src/value-providers/definition.ts
+++ b/languageservice/src/value-providers/definition.ts
@@ -214,10 +214,16 @@ function oneOfValues(
   return distinctValues(values);
 }
 
+/**
+ * Deduplicates values by label and detail.
+ * Values with the same label but different details are preserved as distinct items.
+ */
 function distinctValues(values: Value[]): Value[] {
   const map = new Map<string, Value>();
   for (const value of values) {
-    map.set(value.label, value);
+    // Include detail in the key to preserve variants with different details
+    const key = value.detail ? `${value.label}\0${value.detail}` : value.label;
+    map.set(key, value);
   }
   return Array.from(map.values());
 }
@@ -317,10 +323,10 @@ function expandOneOfToCompletions(
         ? `\n${indentation}${key}:\n${indentation}${indentation}- `
         : `${key}:\n${indentation}- `;
     results.push({
-      label: needsQualifier ? `${key} (list)` : key,
+      label: key,
       description,
+      detail: needsQualifier ? "list" : undefined,
       insertText,
-      filterText: needsQualifier ? key : undefined,
       sortText: needsQualifier ? `${key} 1` : undefined
     });
   }
@@ -331,10 +337,10 @@ function expandOneOfToCompletions(
         ? `\n${indentation}${key}:\n${indentation}${indentation}`
         : `${key}:\n${indentation}`;
     results.push({
-      label: needsQualifier ? `${key} (full syntax)` : key,
+      label: key,
       description,
+      detail: needsQualifier ? "full syntax" : undefined,
       insertText,
-      filterText: needsQualifier ? key : undefined,
       sortText: needsQualifier ? `${key} 2` : undefined
     });
   }


### PR DESCRIPTION
Follow-up to PR:
- https://github.com/actions/languageservices/pull/261

### Problem

When properties have multiple valid structural forms (scalar, list, mapping), we were appending qualifiers to the label like `runs-on (list)` or `concurrency (full syntax)`. This required:
1. Setting `filterText` to the base key so typing "runs-on" would still match all variants
2. Callers to parse the label if they wanted to render the qualifier differently (e.g., dimmed or in a separate column)

### Solution

Use the standard LSP `CompletionItem.detail` field for the qualifier instead. This is the idiomatic approach—`detail` is specifically designed for showing additional information after the label in completion UI.

**Before:**
```
label: "runs-on (list)"
filterText: "runs-on"
```

**After:**
```
label: "runs-on"
detail: "list"
```

### Changes

- Move qualifiers (`list`, `full syntax`) from `label` to `detail` field
- Remove `filterText` since labels are now clean (filtering works automatically)
- Update `distinctValues()` to preserve variants with same label but different details
- Add `detail` field to the `Value` interface and wire it through to `CompletionItem`
