### PR TITLE
Fix autocomplete showing mapping keys for empty values

### DIFF
--- a/languageservice/src/value-providers/definition.ts
+++ b/languageservice/src/value-providers/definition.ts
@@ -198,6 +198,17 @@ function oneOfValues(
       }
     }
 
+    // In Key mode (after colon, e.g., `on: |`), only include scalar variants when
+    // completing an empty value. Mapping/sequence forms require newlines which is
+    // confusing when typing inline. Users who want those forms can use completions
+    // like `(full syntax)` or `(list)` at the parent level.
+    if (!tokenStructure && mode === DefinitionValueMode.Key) {
+      const variantBucket = getStructuralBucket(variantDef.definitionType);
+      if (variantBucket !== "scalar") {
+        continue;
+      }
+    }
+
     values.push(...definitionValues(variantDef, indentation, mode, tokenStructure));
   }
   return distinctValues(values);


### PR DESCRIPTION
Follow-up to PR:
- https://github.com/actions/languageservices/pull/265

## Bug

When completing an empty value (e.g., `permissions: |`), mapping keys were incorrectly shown alongside scalar values. This made completions confusing:

**Before:**
- `permissions: |` showed `read-all`, `write-all`, AND `actions`, `contents`, etc.
- `on: |` showed `check_run` AND `check_run (full syntax)`, etc.

**After:**
- `permissions: |` shows only `read-all` and `write-all`
- `on: |` shows only event names like `push`, `check_run`
- `concurrency: |` shows no completions (user types their own group name)

Users who want the mapping form choose `(full syntax)` completions at the parent level (e.g., `permissions (full syntax)`).