### PR TITLE
Add escape hatch completions to switch structural forms

### DIFF
--- a/languageservice/src/value-providers/config.ts
+++ b/languageservice/src/value-providers/config.ts
@@ -21,6 +21,12 @@ export interface Value {
 
   /** Sort text to control ordering, if not given `label` will be used for sorting */
   sortText?: string;
+
+  /** Custom text edit with specific range, overrides default range calculation */
+  textEdit?: {
+    range: {start: {line: number; character: number}; end: {line: number; character: number}};
+    newText: string;
+  };
 }
 
 export enum ValueProviderKind {


### PR DESCRIPTION
When autocompleting an empty scalar value, users can now switch to alternative structural forms (sequence or mapping) via completion items.

Problem: Scalar form is sorted first at the key level, leading users down this path. Once they trigger autocomplete at `runs-on: |`, they only see scalar values — but they may realize they need a list or the full syntax form.

Solution: Add `(switch to list)` and `(switch to mapping)` completions at the end of the list. Selecting one restructures the YAML to the chosen form.

Example:
```yaml
# User is at:
runs-on: |

# Completions include:
# ubuntu-latest
# ubuntu-24.04
# ...
# (switch to list)      ← selecting this...
# (switch to mapping)

# ...produces:
runs-on:
  - |
```

Design decisions:
- Labels use `(switch to X)` format for clarity
- Sorted last — real options first, escape hatches unobtrusive
- Only shown when value is empty and alternative forms exist
- Shown even when no scalar completions exist (escape from dead ends)
- Uses `TextEdit` to restructure (explicit user intent)