### PR TITLE
Remove filterText from escape hatch completions

### DIFF
--- a/languageservice/src/complete.ts
+++ b/languageservice/src/complete.ts
@@ -399,7 +399,6 @@ function getEscapeHatchCompletions(
     results.push({
       label: "(switch to list)",
       sortText: "zzz_switch_1",
-      filterText: keyName, // Allow filtering by key name
       textEdit: {
         range: editRange,
         newText: `${keyName}:\n${indentation}- `
@@ -411,7 +410,6 @@ function getEscapeHatchCompletions(
     results.push({
       label: "(switch to mapping)",
       sortText: "zzz_switch_2",
-      filterText: keyName, // Allow filtering by key name
       textEdit: {
         range: editRange,
         newText: `${keyName}:\n${indentation}`


### PR DESCRIPTION
Escape hatch completions like '(switch to list)' and '(switch to mapping)' were being filtered out in VS Code because filterText was set to the key name (e.g., 'runs-on'), which doesn't match the empty string at the cursor position when completing a value.

Since escape hatches only appear when the value is empty anyway, there's no need for filterText. Without it, VS Code uses the label for filtering, which properly shows them when no text is typed.