### PR TITLE
Use additionalTextEdits for escape hatch completions

### DIFF
--- a/languageservice/src/value-providers/config.ts
+++ b/languageservice/src/value-providers/config.ts
@@ -27,6 +27,12 @@ export interface Value {
     range: {start: {line: number; character: number}; end: {line: number; character: number}};
     newText: string;
   };
+
+  /** Additional text edits to apply after the main edit (e.g., cleanup edits) */
+  additionalTextEdits?: {
+    range: {start: {line: number; character: number}; end: {line: number; character: number}};
+    newText: string;
+  }[];
 }
 
 export enum ValueProviderKind {


### PR DESCRIPTION
## Problem

The `(switch to list)` and `(switch to mapping)` escape hatch completions are not visible in VS Code. These items work correctly in the Dotcom editor, but VS Code filters them out.

### Root Cause

When the cursor is at a value position like `runs-on: |`, the language service returns escape hatch completions with a `textEdit.range` that spans from the key start to the cursor (covering `runs-on: `). VS Code uses this range to determine the filter text for completions.

| Item | Range | Filter Text | User Typed | Result |
|------|-------|-------------|------------|--------|
| `ubuntu-latest` | char 13→13 | `""` | `""` | ✅ Shown |
| `(switch to list)` | char 4→13 | `"runs-on: "` | `""` | ❌ Filtered out |

Since the user hasn't typed anything matching `"runs-on: "`, VS Code hides the escape hatch items.

## Solution

Split the completion into two edits:

1. **Main `textEdit`**: Insert at cursor position (empty range)
   - Range: cursor → cursor  
   - Text: `":\n  - "` (the newline and list syntax)

2. **`additionalTextEdits`**: Clean up the key
   - Range: key start → cursor
   - Text: `"runs-on"` (replaces `"runs-on: "` with `"runs-on:"`)

This way:
- VS Code sees an empty range for filtering → item passes filter
- The `additionalTextEdits` removes the trailing space when the item is accepted
- Final result is properly formatted YAML:
  ```yaml
  runs-on:
    - |
  ```
