### PR TITLE
Fix completion and validation issues in action.yml

### DIFF
--- a/languageservice/src/complete-action.test.ts
+++ b/languageservice/src/complete-action.test.ts
@@ -262,6 +262,29 @@ runs:
       // It should have a sortText that makes it sort first
       expect(usingCompletion?.sortText).toBe("0_using");
     });
+
+    it("completes step keys inside composite action steps", async () => {
+      const [doc, position] = createActionDocument(`name: Test
+description: Test
+runs:
+  using: composite
+  steps:
+    - run: echo hello
+      shell: bash
+    - |`);
+      const completions = await complete(doc, position);
+      const labels = completions.map(c => c.label);
+
+      // Should show step keys, not filtered by runs-level logic
+      expect(labels).toContain("run");
+      expect(labels).toContain("uses");
+      expect(labels).toContain("shell");
+      expect(labels).toContain("id");
+      expect(labels).toContain("name");
+      expect(labels).toContain("if");
+      expect(labels).toContain("env");
+      expect(labels).toContain("working-directory");
+    });
   });
 
   describe("branding completions", () => {

--- a/languageservice/src/complete.ts
+++ b/languageservice/src/complete.ts
@@ -658,23 +658,15 @@ function filterActionRunsCompletions(values: Value[], path: TemplateToken[], roo
     return values;
   }
 
-  // Also verify we're completing at the runs level, not deeper (like inside steps)
-  // The runs mapping should be the last mapping in the path before the completion position
-  // or the path should only have root -> runs
-  let lastMappingIndex = -1;
-  for (let i = path.length - 1; i >= 0; i--) {
-    if (path[i] instanceof MappingToken) {
-      lastMappingIndex = i;
-      break;
-    }
-  }
-  if (lastMappingIndex === -1) {
+  // Find where runsMapping is in the path
+  const runsMappingIndex = path.indexOf(runsMapping);
+  if (runsMappingIndex === -1) {
     return values;
   }
 
-  // If the last mapping in path is not the runs mapping, we're nested deeper (e.g., inside steps)
-  const lastMapping = path[lastMappingIndex];
-  if (lastMapping !== runsMapping) {
+  // Check if there's anything after runsMapping in the path
+  // If so, we're nested deeper (e.g., inside steps sequence or a step mapping)
+  if (runsMappingIndex < path.length - 1) {
     return values;
   }
 


### PR DESCRIPTION
Follow-up to PR:
- https://github.com/actions/languageservices/pull/289

## What this fixes

**Autocomplete was broken inside composite action steps.** When you typed inside a step and triggered autocomplete, nothing showed up. Now you correctly get suggestions like `run`, `uses`, `shell`, etc.

**Duplicate error messages for missing required fields.** When a required field was missing (like `main` for Node.js actions), users saw two error messages - one generic schema validation error, and one custom error with a clear explanation. Now they only see the custom one.

For example, with `using: node24` but no `main`:
- Before: Two errors shown
  - Schema: `"There's not enough info to determine what you meant. Add one of these properties: args, entrypoint, image, main, ..."`
  - Custom: `"'main' is required for Node.js actions (using: node24)"`
- After: Only the custom error is shown
