### PR TITLE
Add @actions/runner-images-writers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @actions/actions-vscode-reviewers
 
 # Owners maintaining https://github.com/actions/runner-images
-/languageservice/src/value-providers/default.ts @actions/runner-images-writers
+/languageservice/src/value-providers/default.ts @actions/runner-images-writers @actions/actions-vscode-reviewers


### PR DESCRIPTION
## Overview

This PR adds @actions/runner-images-writers to `CODEOWNERS`.