### PR TITLE
Switch to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
 
     env:
       PKG_VERSION: "" # will be set in the workflow
@@ -71,6 +72,7 @@ jobs:
         with:
           node-version: 22.x
           cache: "npm"
+          registry-url: 'https://registry.npmjs.org'
           scope: '@actions'
 
       - name: Parse version from lerna.json
@@ -97,13 +99,6 @@ jobs:
             core.summary.addLink(`Release v${{ env.PKG_VERSION }}`, release.data.html_url);
             await core.summary.write();
 
-      - name: setup authentication
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish packages
         run: |
           lerna publish ${{ env.PKG_VERSION }} --yes --no-git-reset --no-git-tag-version
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Overview

This PR replaces `NPM_TOKEN`-based authentication with OIDC trusted publishing for the release workflow.

### Changes
- Add `id-token: write` permission to the release job (enables OIDC token minting)
- Add `registry-url` to `setup-node` (ensures npm CLI targets the correct registry)
- Remove the "setup authentication" step (no longer needed)
- Remove `NPM_TOKEN` env var from the "Publish packages" step

### Prerequisites
Trusted publisher must be configured on npmjs.com for each package before merging:
- `@actions/expressions`
- `@actions/workflow-parser`
- `@actions/languageservice`
- `@actions/languageserver`

Configuration per package: Settings → Trusted Publisher → GitHub Actions, org=`actions`, repo=`languageservices`, workflow=`release.yml`, environment=`publish`.

### References
- [npm trusted publishers docs](https://docs.npmjs.com/trusted-publishers)
- [npm provenance docs](https://docs.npmjs.com/generating-provenance-statements)