### PR TITLE
Add field_added and field_removed issue event types to workflows

### DIFF
--- a/languageservice/src/complete.test.ts
+++ b/languageservice/src/complete.test.ts
@@ -112,6 +112,19 @@ jobs:
     ]);
   });
 
+  it("issues activity type completion includes field_added and field_removed", async () => {
+    const input = `on:
+  issues:
+    types:
+      - |`;
+    const result = await complete(...getPositionFromCursor(input));
+    const labels = result.map(x => x.label);
+    expect(labels).toContain("field_added");
+    expect(labels).toContain("field_removed");
+    expect(labels).toContain("opened");
+    expect(labels).toContain("closed");
+  });
+
   it("map keys filter out existing values", async () => {
     const input = `on: push
 jobs:

--- a/languageservice/src/context-providers/events/webhooks.json
+++ b/languageservice/src/context-providers/events/webhooks.json
@@ -6209,30 +6209,6 @@
         6
       ],
       "action": "unpinned"
-    },
-    "field_added": {
-      "bodyParameters": [
-        0,
-        1,
-        2,
-        23,
-        3,
-        4,
-        6
-      ],
-      "action": "field_added"
-    },
-    "field_removed": {
-      "bodyParameters": [
-        0,
-        1,
-        2,
-        23,
-        3,
-        4,
-        6
-      ],
-      "action": "field_removed"
     }
   },
   "label": {

--- a/languageservice/src/context-providers/events/webhooks.json
+++ b/languageservice/src/context-providers/events/webhooks.json
@@ -6209,6 +6209,30 @@
         6
       ],
       "action": "unpinned"
+    },
+    "field_added": {
+      "bodyParameters": [
+        0,
+        1,
+        2,
+        23,
+        3,
+        4,
+        6
+      ],
+      "action": "field_added"
+    },
+    "field_removed": {
+      "bodyParameters": [
+        0,
+        1,
+        2,
+        23,
+        3,
+        4,
+        6
+      ],
+      "action": "field_removed"
     }
   },
   "label": {

--- a/languageservice/src/validate.test.ts
+++ b/languageservice/src/validate.test.ts
@@ -165,6 +165,43 @@ jobs:
     } as Diagnostic);
   });
 
+  it("issues event with field_added activity type", async () => {
+    const result = await validate(
+      createDocument(
+        "wf.yaml",
+        `on:
+  issues:
+    types: [field_added, field_removed]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo`
+      )
+    );
+
+    expect(result.length).toBe(0);
+  });
+
+  it("issues event with invalid activity type", async () => {
+    const result = await validate(
+      createDocument(
+        "wf.yaml",
+        `on:
+  issues:
+    types: [opened, not_a_real_type]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo`
+      )
+    );
+
+    expect(result.length).toBe(1);
+    expect(result[0]?.message).toBe("Unexpected value 'not_a_real_type'");
+  });
+
   it("invalid cron string", async () => {
     const result = await validate(
       createDocument(

--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -539,7 +539,7 @@
       }
     },
     "issues-activity": {
-      "description": "The types of issue activity that trigger the workflow. Supported activity types: `opened`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `closed`, `reopened`, `assigned`, `unassigned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `milestoned`, `demilestoned`.",
+      "description": "The types of issue activity that trigger the workflow. Supported activity types: `opened`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `closed`, `reopened`, `assigned`, `unassigned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `milestoned`, `demilestoned`, `field_added`, `field_removed`.",
       "one-of": [
         "issues-activity-type",
         "issues-activity-types"
@@ -567,7 +567,9 @@
         "locked",
         "unlocked",
         "milestoned",
-        "demilestoned"
+        "demilestoned",
+        "field_added",
+        "field_removed"
       ]
     },
     "label-string": {

--- a/workflow-parser/testdata/reader/events-mapping-all.yml
+++ b/workflow-parser/testdata/reader/events-mapping-all.yml
@@ -318,7 +318,9 @@ jobs:
         "locked",
         "unlocked",
         "milestoned",
-        "demilestoned"
+        "demilestoned",
+        "field_added",
+        "field_removed"
       ]
     },
     "label": {

--- a/workflow-parser/testdata/reader/events-mapping-all.yml
+++ b/workflow-parser/testdata/reader/events-mapping-all.yml
@@ -66,6 +66,8 @@ on:
       - unlocked
       - milestoned
       - demilestoned
+      - field_added
+      - field_removed
   label:
     types:
       - created


### PR DESCRIPTION
Workflow authors get validation errors when using `field_added` and `field_removed` types even though they are valid actions. 

- Related issue : https://github.com/github/issues/issues/20769

### Summary

Adds `field_added` and `field_removed` as supported activity types for the issues workflow trigger. This enables autocomplete, validation, and proper `github.event` payload resolution for these event types in GitHub Actions workflow files.

### Changes

####  Schema 
- Added `field_added` and `field_removed` to the issues-activity-type allowed values in workflow-v1.0.json
- Updated the issues-activity description to list the new types
- Added the new types to the events-mapping-all.yml test fixture 

#### Webhook payloads

- Added `field_added` and `field_removed` entries under issues in `webhooks.json` with the standard issue event payload (action, enterprise, installation, issue, organization, repository, sender)


#### Tests

- Added a completion test verifying field_added and field_removed appear in autocomplete suggestions for issues activity types
- Added a validation test confirming field_added and field_removed are accepted without errors
- Added a negative validation test confirming invalid activity types are still rejected
