### PR TITLE
Add background step syntax to workflow parser and language service

### DIFF
--- a/expressions/src/features.test.ts
+++ b/expressions/src/features.test.ts
@@ -57,7 +57,8 @@ describe("FeatureFlags", () => {
         "blockScalarChompingWarning",
         "allowCaseFunction",
         "allowCopilotRequestsPermission",
-        "allowConcurrencyQueue"
+        "allowConcurrencyQueue",
+        "allowBackgroundSteps"
       ]);
     });
   });

--- a/expressions/src/features.ts
+++ b/expressions/src/features.ts
@@ -46,6 +46,12 @@ export interface ExperimentalFeatures {
    * @default false
    */
   allowConcurrencyQueue?: boolean;
+
+  /**
+   * Enable background workflow steps and related wait/cancel steps.
+   * @default false
+   */
+  allowBackgroundSteps?: boolean;
 }
 
 /**
@@ -62,7 +68,8 @@ const allFeatureKeys: ExperimentalFeatureKey[] = [
   "blockScalarChompingWarning",
   "allowCaseFunction",
   "allowCopilotRequestsPermission",
-  "allowConcurrencyQueue"
+  "allowConcurrencyQueue",
+  "allowBackgroundSteps"
 ];
 
 export class FeatureFlags {

--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -128,6 +128,7 @@ initializationOptions: {
 | `missingInputsQuickfix` | Code action to add missing required inputs for actions |
 | `blockScalarChompingWarning` | Warn when block scalars (`\|` or `>`) use implicit clip chomping, which adds a trailing newline that may be unintentional |
 | `allowConcurrencyQueue` | Enable the `concurrency.queue` workflow property |
+| `allowBackgroundSteps` | Enable background workflow steps and related wait/cancel steps |
 
 Individual feature flags take precedence over `all`. For example, `{ all: true, missingInputsQuickfix: false }` enables all experimental features except `missingInputsQuickfix`.
 

--- a/languageserver/src/connection.ts
+++ b/languageserver/src/connection.ts
@@ -168,7 +168,8 @@ export function initConnection(connection: Connection) {
         contextProviderConfig: repoContext && contextProviders(client, repoContext, cache),
         fileProvider: getFileProvider(client, cache, repoContext?.workspaceUri, async path => {
           return await connection.sendRequest(Requests.ReadFile, {path});
-        })
+        }),
+        featureFlags
       });
     });
   });

--- a/languageservice/src/complete.test.ts
+++ b/languageservice/src/complete.test.ts
@@ -305,25 +305,41 @@ jobs:
     - run: echo
     - |`;
     const result = await complete(...getPositionFromCursor(input));
-    expect(result).toHaveLength(11);
-    expect(result.map(x => x.label)).toEqual([
-      "continue-on-error",
-      "env",
-      "id",
-      "if",
-      "name",
-      "run",
-      "shell",
-      "timeout-minutes",
-      "uses",
-      "with",
-      "working-directory"
-    ]);
+    expect(result.map(x => x.label)).toEqual(
+      expect.arrayContaining([
+        "continue-on-error",
+        "env",
+        "id",
+        "if",
+        "name",
+        "run",
+        "shell",
+        "timeout-minutes",
+        "uses",
+        "with",
+        "working-directory"
+      ])
+    );
+    expect(result.map(x => x.label)).toEqual(expect.not.arrayContaining(["background", "cancel", "wait", "wait-all"]));
 
     // Includes detail when available. Using continue-on-error as a sample here.
     expect(result.map(x => (x.documentation as MarkupContent)?.value)).toContain(
       "Prevents a job from failing when a step fails. Set to `true` to allow a job to pass when this step fails."
     );
+  });
+
+  it("empty step includes background step keys when enabled", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo
+    - |`;
+    const result = await complete(...getPositionFromCursor(input), {
+      featureFlags: new FeatureFlags({allowBackgroundSteps: true})
+    });
+    expect(result.map(x => x.label)).toEqual(expect.arrayContaining(["background", "cancel", "wait", "wait-all"]));
   });
 
   it("loose mapping keys have no completion suggestions", async () => {

--- a/languageservice/src/complete.ts
+++ b/languageservice/src/complete.ts
@@ -42,6 +42,8 @@ import {Value, ValueProviderConfig} from "./value-providers/config.js";
 import {defaultValueProviders} from "./value-providers/default.js";
 import {DefinitionValueMode, definitionValues, TokenStructure} from "./value-providers/definition.js";
 
+const backgroundStepCompletionLabels = new Set(["background", "wait", "wait-all", "cancel"]);
+
 export function getExpressionInput(input: string, pos: number): string {
   // Find start marker around the cursor position
   let startPos = input.lastIndexOf(OPEN_EXPRESSION, pos);
@@ -88,7 +90,7 @@ export async function complete(
   // Parse the document
   const parsedTemplate = isAction
     ? getOrParseAction(file, textDocument.uri, true)
-    : getOrParseWorkflow(file, textDocument.uri, true);
+    : getOrParseWorkflow(file, textDocument.uri, true, config?.featureFlags);
   if (!parsedTemplate.value) {
     return [];
   }
@@ -170,6 +172,10 @@ export async function complete(
     parent?.definition?.key === "permissions-mapping"
   ) {
     values = values.filter(v => v.label !== "copilot-requests");
+  }
+
+  if (!isAction && !config?.featureFlags?.isEnabled("allowBackgroundSteps")) {
+    values = values.filter(v => !backgroundStepCompletionLabels.has(v.label));
   }
 
   // Offer "(switch to list)" / "(switch to mapping)" when the schema allows alternative forms

--- a/languageservice/src/context-providers/env.ts
+++ b/languageservice/src/context-providers/env.ts
@@ -7,7 +7,7 @@ export function getEnvContext(workflowContext: WorkflowContext): DescriptionDict
   const d = new DescriptionDictionary();
 
   //step env
-  if (workflowContext.step?.env) {
+  if (workflowContext.step && "env" in workflowContext.step && workflowContext.step.env) {
     envContext(workflowContext.step.env, d);
   }
 

--- a/languageservice/src/context/workflow-context.ts
+++ b/languageservice/src/context/workflow-context.ts
@@ -67,7 +67,10 @@ export function getWorkflowContext(
         break;
       }
       case "regular-step":
-      case "run-step": {
+      case "run-step":
+      case "wait-step":
+      case "wait-all-step":
+      case "cancel-step": {
         if (isMapping(token)) {
           stepToken = token;
         }

--- a/languageservice/src/hover.test.ts
+++ b/languageservice/src/hover.test.ts
@@ -1,3 +1,4 @@
+import {FeatureFlags} from "@actions/expressions";
 import {isString} from "@actions/workflow-parser";
 import {DescriptionProvider, hover, HoverConfig} from "./hover.js";
 import {getPositionFromCursor} from "./test-utils/cursor-position.js";
@@ -201,5 +202,81 @@ jobs:
     expect(result?.contents).toEqual(
       "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, a [private repository with access enabled](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository), or in a published Docker container image."
     );
+  });
+});
+
+describe("hover for background step keywords", () => {
+  const bgConfig: HoverConfig = {featureFlags: new FeatureFlags({allowBackgroundSteps: true})};
+
+  it("on background key", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: echo hi
+        ba|ckground: true`;
+    const result = await hover(...getPositionFromCursor(input), bgConfig);
+    expect(result).not.toBeNull();
+    expect(result?.contents).toContain("runs this step in the background");
+  });
+
+  it("on wait key", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: echo hi
+        background: true
+      - wa|it: server`;
+    const result = await hover(...getPositionFromCursor(input), bgConfig);
+    expect(result).not.toBeNull();
+    expect(result?.contents).toContain("background steps to wait for");
+  });
+
+  it("on wait-all key", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: echo hi
+        background: true
+      - wa|it-all:`;
+    const result = await hover(...getPositionFromCursor(input), bgConfig);
+    expect(result).not.toBeNull();
+    expect(result?.contents).toContain("Wait for all prior background steps");
+  });
+
+  it("on cancel key", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: echo hi
+        background: true
+      - ca|ncel: server`;
+    const result = await hover(...getPositionFromCursor(input), bgConfig);
+    expect(result).not.toBeNull();
+    expect(result?.contents).toContain("background step to cancel");
+  });
+
+  it("no hover for background keywords when feature flag is off", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: echo hi
+        ba|ckground: true`;
+    const result = await hover(...getPositionFromCursor(input));
+    expect(result).toBeNull();
   });
 });

--- a/languageservice/src/hover.ts
+++ b/languageservice/src/hover.ts
@@ -1,4 +1,4 @@
-import {data, DescriptionDictionary, Parser} from "@actions/expressions";
+import {data, DescriptionDictionary, FeatureFlags, Parser} from "@actions/expressions";
 import {FunctionDefinition, FunctionInfo} from "@actions/expressions/funcs/info";
 import {Lexer} from "@actions/expressions/lexer";
 import {parseAction} from "@actions/workflow-parser/actions/action-parser";
@@ -35,6 +35,7 @@ export type HoverConfig = {
   descriptionProvider?: DescriptionProvider;
   contextProviderConfig?: ContextProviderConfig;
   fileProvider?: FileProvider;
+  featureFlags?: FeatureFlags;
 };
 
 export type DescriptionProvider = {
@@ -58,7 +59,9 @@ export async function hover(document: TextDocument, position: Position, config?:
   const isAction = isActionDocument(document.uri);
 
   // Parse document
-  const parsedTemplate = isAction ? parseAction(file, nullTrace) : getOrParseWorkflow(file, document.uri);
+  const parsedTemplate = isAction
+    ? parseAction(file, nullTrace)
+    : getOrParseWorkflow(file, document.uri, false, config?.featureFlags);
   if (!parsedTemplate?.value) {
     return null;
   }

--- a/languageservice/src/utils/workflow-cache.ts
+++ b/languageservice/src/utils/workflow-cache.ts
@@ -1,3 +1,4 @@
+import {FeatureFlags} from "@actions/expressions";
 import {convertWorkflowTemplate, parseWorkflow, TemplateParseResult, WorkflowTemplate} from "@actions/workflow-parser";
 import {parseAction} from "@actions/workflow-parser/actions/action-parser";
 import {
@@ -6,9 +7,10 @@ import {
   convertActionTemplate
 } from "@actions/workflow-parser/actions/action-template";
 import {WorkflowTemplateConverterOptions} from "@actions/workflow-parser/model/convert";
-import {TemplateContext} from "@actions/workflow-parser/templates/template-context";
+import {TemplateContext, TemplateValidationErrors} from "@actions/workflow-parser/templates/template-context";
 import {TemplateToken} from "@actions/workflow-parser/templates/tokens/template-token";
 import {File} from "@actions/workflow-parser/workflows/file";
+import {getWorkflowSchema} from "@actions/workflow-parser/workflows/workflow-schema";
 
 import {CompletionConfig} from "../complete.js";
 import {nullTrace} from "../nulltrace.js";
@@ -41,13 +43,20 @@ export function clearCache() {
  * @param transformed Indicates whether the workflow has been transformed before parsing
  * @returns the {@link TemplateParseResult}
  */
-export function getOrParseWorkflow(file: File, uri: string, transformed = false): TemplateParseResult {
+export function getOrParseWorkflow(
+  file: File,
+  uri: string,
+  transformed = false,
+  featureFlags?: FeatureFlags
+): TemplateParseResult {
   const key = cacheKey(uri, transformed);
   const cachedResult = parsedWorkflowCache.get(key);
   if (cachedResult) {
     return cachedResult;
   }
-  const result = parseWorkflow(file, nullTrace);
+  const context = new TemplateContext(new TemplateValidationErrors(), getWorkflowSchema(), nullTrace);
+  context.state.featureFlags = featureFlags;
+  const result = parseWorkflow(file, context);
   parsedWorkflowCache.set(key, result);
   return result;
 }

--- a/languageservice/src/validate.test.ts
+++ b/languageservice/src/validate.test.ts
@@ -1,3 +1,4 @@
+import {FeatureFlags} from "@actions/expressions";
 import {Diagnostic, DiagnosticSeverity} from "vscode-languageserver-types";
 import {createDocument} from "./test-utils/document.js";
 import {validate} from "./validate.js";
@@ -14,6 +15,99 @@ describe("validation", () => {
     const result = await validate(createDocument("wf.yaml", "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest"));
 
     expect(result.length).toBe(0);
+  });
+
+  it("background step keywords are accepted when enabled", async () => {
+    const result = await validate(
+      createDocument(
+        "wf.yaml",
+        `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: npm start
+        background: true
+      - wait: server
+        continue-on-error: true
+      - wait-all:
+        continue-on-error: false
+      - cancel: server`
+      ),
+      {featureFlags: new FeatureFlags({allowBackgroundSteps: true})}
+    );
+
+    expect(result.length).toBe(0);
+  });
+
+  it("background step keywords are rejected when disabled", async () => {
+    const result = await validate(
+      createDocument(
+        "wf.yaml",
+        `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: npm start
+        background: true
+      - wait: server
+      - wait-all:
+      - cancel: server`
+      )
+    );
+
+    expect(result.map(x => x.message)).toEqual([
+      "Unexpected value 'background'",
+      "Unexpected value 'wait'",
+      "Unexpected value 'wait-all'",
+      "Unexpected value 'cancel'",
+      "Expected one of uses, run, wait, wait-all, or cancel to be defined",
+      "Expected one of uses, run, wait, wait-all, or cancel to be defined",
+      "Expected one of uses, run, wait, wait-all, or cancel to be defined"
+    ]);
+  });
+
+  it("background step keywords are included in ambiguity errors when enabled", async () => {
+    const result = await validate(
+      createDocument(
+        "wf.yaml",
+        `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - runn: echo hi`
+      ),
+      {featureFlags: new FeatureFlags({allowBackgroundSteps: true})}
+    );
+
+    expect(result.map(x => x.message)).toContain(
+      "There's not enough info to determine what you meant. Add one of these properties: cancel, run, shell, uses, wait, wait-all, with, working-directory"
+    );
+  });
+
+  it("wait-all false is rejected", async () => {
+    const result = await validate(
+      createDocument(
+        "wf.yaml",
+        `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - wait-all: false`
+      ),
+      {featureFlags: new FeatureFlags({allowBackgroundSteps: true})}
+    );
+
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        message: "The value of 'wait-all' must be true or omitted"
+      })
+    );
   });
 
   it("missing jobs key", async () => {

--- a/languageservice/src/validate.test.ts
+++ b/languageservice/src/validate.test.ts
@@ -64,9 +64,9 @@ jobs:
       "Unexpected value 'wait'",
       "Unexpected value 'wait-all'",
       "Unexpected value 'cancel'",
-      "Expected one of uses, run, wait, wait-all, or cancel to be defined",
-      "Expected one of uses, run, wait, wait-all, or cancel to be defined",
-      "Expected one of uses, run, wait, wait-all, or cancel to be defined"
+      "Expected one of uses or run to be defined",
+      "Expected one of uses or run to be defined",
+      "Expected one of uses or run to be defined"
     ]);
   });
 

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -82,7 +82,12 @@ async function validateWorkflow(textDocument: TextDocument, config?: ValidationC
   const diagnostics: Diagnostic[] = [];
 
   try {
-    const result: TemplateParseResult | undefined = getOrParseWorkflow(file, textDocument.uri);
+    const result: TemplateParseResult | undefined = getOrParseWorkflow(
+      file,
+      textDocument.uri,
+      false,
+      config?.featureFlags
+    );
     if (!result) {
       return [];
     }

--- a/workflow-parser/src/model/convert.test.ts
+++ b/workflow-parser/src/model/convert.test.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {FeatureFlags} from "@actions/expressions";
 import {nullTrace} from "../test-utils/null-trace.js";
+import {TemplateContext, TemplateValidationErrors} from "../templates/template-context.js";
 import {parseWorkflow} from "../workflows/workflow-parser.js";
+import {getWorkflowSchema} from "../workflows/workflow-schema.js";
 import {convertWorkflowTemplate, ErrorPolicy} from "./convert.js";
 
 function serializeTemplate(template: unknown): unknown {
@@ -8,6 +11,84 @@ function serializeTemplate(template: unknown): unknown {
 }
 
 describe("convertWorkflowTemplate", () => {
+  it("rejects background steps when feature flag is disabled", async () => {
+    const result = parseWorkflow(
+      {
+        name: "wf.yaml",
+        content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: npm start
+        background: true
+      - wait-all:`
+      },
+      nullTrace
+    );
+
+    const template = await convertWorkflowTemplate(result.context, result.value!, undefined, {
+      errorPolicy: ErrorPolicy.ReturnErrorsOnly
+    });
+
+    expect(serializeTemplate(template)).toMatchObject({
+      errors: [
+        {
+          Message: "wf.yaml (Line: 8, Col: 9): Unexpected value 'background'"
+        },
+        {
+          Message: "wf.yaml (Line: 9, Col: 9): Unexpected value 'wait-all'"
+        }
+      ]
+    });
+  });
+
+  it("accepts background steps when feature flag is enabled", async () => {
+    const context = new TemplateContext(new TemplateValidationErrors(), getWorkflowSchema(), nullTrace);
+    context.state.featureFlags = new FeatureFlags({allowBackgroundSteps: true});
+
+    const result = parseWorkflow(
+      {
+        name: "wf.yaml",
+        content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: npm start
+        background: true
+      - wait-all:`
+      },
+      context
+    );
+
+    const template = await convertWorkflowTemplate(result.context, result.value!, undefined, {
+      errorPolicy: ErrorPolicy.TryConversion,
+      featureFlags: new FeatureFlags({allowBackgroundSteps: true})
+    });
+
+    expect(serializeTemplate(template)).toMatchObject({
+      jobs: [
+        {
+          steps: [
+            {
+              id: "server",
+              background: true,
+              run: "npm start"
+            },
+            {
+              id: "__wait-all",
+              "wait-all": true
+            }
+          ]
+        }
+      ]
+    });
+    expect(template.errors).toBeUndefined();
+  });
+
   it("converts workflow with one job", async () => {
     const result = parseWorkflow(
       {

--- a/workflow-parser/src/model/converter/steps.ts
+++ b/workflow-parser/src/model/converter/steps.ts
@@ -13,6 +13,7 @@ import {convertToIfCondition} from "./if-condition.js";
 import {ActionStep, Step} from "../workflow-template.js";
 import {handleTemplateTokenErrors} from "./handle-errors.js";
 import {IdBuilder} from "./id-builder.js";
+import {FeatureFlags} from "@actions/expressions/features";
 
 export function convertSteps(context: TemplateContext, steps: TemplateToken): Step[] {
   if (!isSequence(steps)) {
@@ -180,7 +181,12 @@ function convertStep(
       cancel
     };
   }
-  context.error(step, "Expected one of uses, run, wait, wait-all, or cancel to be defined");
+  context.error(
+    step,
+    (context.state.featureFlags as FeatureFlags | undefined)?.isEnabled("allowBackgroundSteps")
+      ? "Expected one of uses, run, wait, wait-all, or cancel to be defined"
+      : "Expected one of uses or run to be defined"
+  );
 }
 
 function createActionStepId(step: ActionStep): string {

--- a/workflow-parser/src/model/converter/steps.ts
+++ b/workflow-parser/src/model/converter/steps.ts
@@ -2,6 +2,7 @@ import {TemplateContext} from "../../templates/template-context.js";
 import {
   BasicExpressionToken,
   MappingToken,
+  NullToken,
   ScalarToken,
   StringToken,
   TemplateToken
@@ -20,10 +21,13 @@ export function convertSteps(context: TemplateContext, steps: TemplateToken): St
   }
 
   const idBuilder = new IdBuilder();
+  const knownStepIds = new Set<string>();
 
   const result: Step[] = [];
   for (const item of steps) {
-    const step = handleTemplateTokenErrors(steps, context, undefined, () => convertStep(context, idBuilder, item));
+    const step = handleTemplateTokenErrors(steps, context, undefined, () =>
+      convertStep(context, idBuilder, knownStepIds, item)
+    );
     if (step) {
       result.push(step);
     }
@@ -37,6 +41,12 @@ export function convertSteps(context: TemplateContext, steps: TemplateToken): St
     let id = "";
     if (isActionStep(step)) {
       id = createActionStepId(step);
+    } else if ("wait" in step) {
+      id = "wait";
+    } else if ("wait-all" in step) {
+      id = "wait-all";
+    } else if ("cancel" in step) {
+      id = "cancel";
     }
 
     if (!id) {
@@ -50,13 +60,22 @@ export function convertSteps(context: TemplateContext, steps: TemplateToken): St
   return result;
 }
 
-function convertStep(context: TemplateContext, idBuilder: IdBuilder, step: TemplateToken): Step | undefined {
+function convertStep(
+  context: TemplateContext,
+  idBuilder: IdBuilder,
+  knownStepIds: Set<string>,
+  step: TemplateToken
+): Step | undefined {
   const mapping = step.assertMapping("steps item");
 
   let run: ScalarToken | undefined;
   let id: StringToken | undefined;
   let name: ScalarToken | undefined;
   let uses: StringToken | undefined;
+  let background: boolean | undefined;
+  let wait: StringToken[] | undefined;
+  let waitAll: boolean | undefined;
+  let cancel: StringToken | undefined;
   let continueOnError: boolean | ScalarToken | undefined;
   let env: MappingToken | undefined;
   let ifCondition: BasicExpressionToken | undefined;
@@ -69,6 +88,8 @@ function convertStep(context: TemplateContext, idBuilder: IdBuilder, step: Templ
           const error = idBuilder.tryAddKnownId(id.value);
           if (error) {
             context.error(id, error);
+          } else {
+            knownStepIds.add(id.value);
           }
         }
         break;
@@ -80,6 +101,19 @@ function convertStep(context: TemplateContext, idBuilder: IdBuilder, step: Templ
         break;
       case "uses":
         uses = item.value.assertString("steps item uses");
+        break;
+      case "background":
+        background = item.value.assertBoolean("steps item background").value;
+        break;
+      case "wait":
+        wait = convertWaitTargets(context, knownStepIds, item.value, id);
+        break;
+      case "wait-all":
+        waitAll = convertWaitAllValue(context, item.value);
+        break;
+      case "cancel":
+        cancel = item.value.assertString("steps item cancel");
+        validateTargetStepId(context, knownStepIds, cancel, id);
         break;
       case "env":
         env = item.value.assertMapping("step env");
@@ -103,7 +137,8 @@ function convertStep(context: TemplateContext, idBuilder: IdBuilder, step: Templ
       if: ifCondition || new BasicExpressionToken(undefined, undefined, "success()", undefined, undefined, undefined),
       "continue-on-error": continueOnError,
       env,
-      run
+      run,
+      background
     };
   }
 
@@ -114,10 +149,38 @@ function convertStep(context: TemplateContext, idBuilder: IdBuilder, step: Templ
       if: ifCondition || new BasicExpressionToken(undefined, undefined, "success()", undefined, undefined, undefined),
       "continue-on-error": continueOnError,
       env,
-      uses
+      uses,
+      background
     };
   }
-  context.error(step, "Expected uses or run to be defined");
+
+  if (wait) {
+    return {
+      id: id?.value || "",
+      name: name || createSyntheticStepName("Wait"),
+      "continue-on-error": continueOnError,
+      wait
+    };
+  }
+
+  if (waitAll !== undefined) {
+    return {
+      id: id?.value || "",
+      name: name || createSyntheticStepName("Wait for all"),
+      "continue-on-error": continueOnError,
+      "wait-all": waitAll
+    };
+  }
+
+  if (cancel) {
+    return {
+      id: id?.value || "",
+      name: name || createSyntheticStepName("Cancel"),
+      "continue-on-error": continueOnError,
+      cancel
+    };
+  }
+  context.error(step, "Expected one of uses, run, wait, wait-all, or cancel to be defined");
 }
 
 function createActionStepId(step: ActionStep): string {
@@ -143,4 +206,58 @@ function createActionStepId(step: ActionStep): string {
   }
 
   return "";
+}
+
+function createSyntheticStepName(value: string): ScalarToken {
+  return new StringToken(undefined, undefined, value, undefined, undefined, undefined);
+}
+
+function convertWaitTargets(
+  context: TemplateContext,
+  knownStepIds: Set<string>,
+  token: TemplateToken,
+  ownStepId?: StringToken
+): StringToken[] {
+  if (token instanceof StringToken) {
+    validateTargetStepId(context, knownStepIds, token, ownStepId);
+    return [token];
+  }
+
+  const sequence = token.assertSequence("steps item wait");
+  const targets: StringToken[] = [];
+  for (let i = 0; i < sequence.count; i++) {
+    const target = sequence.get(i).assertString("steps item wait item");
+    validateTargetStepId(context, knownStepIds, target, ownStepId);
+    targets.push(target);
+  }
+
+  return targets;
+}
+
+function convertWaitAllValue(context: TemplateContext, token: TemplateToken): boolean {
+  if (token instanceof NullToken) {
+    return true;
+  }
+
+  const value = token.assertBoolean("steps item wait-all").value;
+  if (!value) {
+    context.error(token, "The value of 'wait-all' must be true or omitted");
+  }
+
+  return true;
+}
+
+function validateTargetStepId(
+  context: TemplateContext,
+  knownStepIds: Set<string>,
+  target: StringToken,
+  ownStepId?: StringToken
+) {
+  if (target.value.startsWith("__")) {
+    context.error(target, `The identifier '${target.value}' is invalid. IDs starting with '__' are reserved.`);
+  } else if (ownStepId && target.value.toLowerCase() === ownStepId.value.toLowerCase()) {
+    context.error(target, `Step '${ownStepId.value}' cannot reference itself`);
+  } else if (!knownStepIds.has(target.value)) {
+    context.error(target, `Step references unknown step ID '${target.value}'`);
+  }
 }

--- a/workflow-parser/src/model/workflow-template.ts
+++ b/workflow-parser/src/model/workflow-template.ts
@@ -87,22 +87,40 @@ export type Credential = {
   password: StringToken | undefined;
 };
 
-export type Step = ActionStep | RunStep;
+export type Step = ActionStep | RunStep | WaitStep | WaitAllStep | CancelStep;
 
 type BaseStep = {
   id: string;
   name?: ScalarToken;
-  if: BasicExpressionToken;
+  if?: BasicExpressionToken;
   "continue-on-error"?: boolean | ScalarToken;
+};
+
+type ExecutionStep = BaseStep & {
+  if: BasicExpressionToken;
   env?: MappingToken;
 };
 
-export type RunStep = BaseStep & {
+export type RunStep = ExecutionStep & {
   run: ScalarToken;
+  background?: boolean;
 };
 
-export type ActionStep = BaseStep & {
+export type ActionStep = ExecutionStep & {
   uses: StringToken;
+  background?: boolean;
+};
+
+export type WaitStep = BaseStep & {
+  wait: StringToken[];
+};
+
+export type WaitAllStep = BaseStep & {
+  "wait-all": boolean;
+};
+
+export type CancelStep = BaseStep & {
+  cancel: StringToken;
 };
 
 export type EventsConfig = {

--- a/workflow-parser/src/templates/template-reader.ts
+++ b/workflow-parser/src/templates/template-reader.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import {ObjectReader} from "./object-reader.js";
+import {FeatureFlags} from "@actions/expressions/features";
 import {TemplateSchema} from "./schema/index.js";
 import {DefinitionInfo} from "./schema/definition-info.js";
 import {DefinitionType} from "./schema/definition-type.js";
@@ -25,6 +26,8 @@ import {isString} from "./tokens/type-guards.js";
 import {TokenType} from "./tokens/types.js";
 
 const WHITESPACE_PATTERN = /\s/;
+const backgroundStepProperties = new Set(["background", "wait", "wait-all", "cancel"]);
+const backgroundStepOnlyProperties = new Set(["wait", "wait-all", "cancel"]);
 
 export function readTemplate(
   context: TemplateContext,
@@ -215,6 +218,12 @@ class TemplateReader {
       // Well known
       const nextPropertyDef = this._schema.matchPropertyAndFilter(mappingDefinitions, nextKey.value);
       if (nextPropertyDef) {
+        if (!this.backgroundStepsEnabled() && backgroundStepProperties.has(nextKey.value)) {
+          this._context.error(nextKey, `Unexpected value '${nextKey.value}'`);
+          this.skipValue();
+          continue;
+        }
+
         const nextDefinition = new DefinitionInfo(definition, nextPropertyDef.type);
 
         // Store the definition on the key, the value may have its own definition
@@ -277,9 +286,13 @@ class TemplateReader {
         }
       }
 
+      const properties = this.backgroundStepsEnabled()
+        ? nonDuplicates
+        : nonDuplicates.filter(property => !backgroundStepOnlyProperties.has(property));
+
       this._context.error(
         mapping,
-        `There's not enough info to determine what you meant. Add one of these properties: ${nonDuplicates
+        `There's not enough info to determine what you meant. Add one of these properties: ${properties
           .sort()
           .join(", ")}`
       );
@@ -792,6 +805,10 @@ class TemplateReader {
     }
 
     return result.join("");
+  }
+
+  private backgroundStepsEnabled(): boolean {
+    return (this._context.state.featureFlags as FeatureFlags | undefined)?.isEnabled("allowBackgroundSteps") ?? false;
   }
 }
 

--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -2146,7 +2146,7 @@
       }
     },
     "steps": {
-      "description": "A job contains a sequence of tasks called `steps`. Steps can run commands, run setup tasks, or run an action in your repository, a public repository, or an action published in a Docker registry. Not all steps run actions, but all actions run as a step. Each step runs in its own process in the runner environment and has access to the workspace and filesystem. Because steps run in their own process, changes to environment variables are not preserved between steps. GitHub provides built-in steps to set up and complete a job. Must contain either `uses` or `run`.",
+      "description": "A job contains a sequence of tasks called `steps`. Steps can run commands, run setup tasks, run an action in your repository, a public repository, or an action published in a Docker registry, wait for background steps to complete, or cancel a background step. Not all steps run actions, but all actions run as a step. Each step runs in its own process in the runner environment and has access to the workspace and filesystem. Because steps run in their own process, changes to environment variables are not preserved between steps. GitHub provides built-in steps to set up and complete a job.",
       "sequence": {
         "item-type": "steps-item"
       }
@@ -2154,7 +2154,10 @@
     "steps-item": {
       "one-of": [
         "run-step",
-        "regular-step"
+        "regular-step",
+        "wait-step",
+        "wait-all-step",
+        "cancel-step"
       ]
     },
     "run-step": {
@@ -2172,7 +2175,8 @@
           "continue-on-error": "step-continue-on-error",
           "env": "step-env",
           "working-directory": "string-steps-context",
-          "shell": "shell"
+          "shell": "shell",
+          "background": "step-background"
         }
       }
     },
@@ -2189,12 +2193,76 @@
             "required": true
           },
           "with": "step-with",
-          "env": "step-env"
+          "env": "step-env",
+          "background": "step-background"
+        }
+      }
+    },
+    "wait-step": {
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait": {
+            "type": "step-wait-target",
+            "required": true
+          }
+        }
+      }
+    },
+    "wait-all-step": {
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait-all": {
+            "type": "step-wait-all-value",
+            "required": true
+          }
+        }
+      }
+    },
+    "cancel-step": {
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "cancel": {
+            "type": "step-cancel-target",
+            "required": true
+          }
         }
       }
     },
     "step-uses": {
       "description": "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, a [private repository with access enabled](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository), or in a published Docker container image.",
+      "string": {
+        "require-non-empty": true
+      }
+    },
+    "step-background": {
+      "boolean": {},
+      "description": "When set to true, runs this step in the background. The workflow continues to the next step immediately without waiting for the background step to finish."
+    },
+    "step-wait-target": {
+      "description": "The step ID or IDs of background steps to wait for.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "step-wait-all-value": {
+      "description": "Wait for all prior background steps to complete. Use as a bare key (`wait-all:`) or with a boolean value.",
+      "one-of": [
+        "null",
+        "boolean"
+      ]
+    },
+    "step-cancel-target": {
+      "description": "The step ID of a background step to cancel.",
       "string": {
         "require-non-empty": true
       }

--- a/workflow-parser/src/workflows/workflow-parser.test.ts
+++ b/workflow-parser/src/workflows/workflow-parser.test.ts
@@ -1,5 +1,15 @@
+import {FeatureFlags} from "@actions/expressions";
+import {TemplateContext, TemplateValidationErrors} from "../templates/template-context.js";
 import {parseWorkflow} from "./workflow-parser.js";
+import {getWorkflowSchema} from "./workflow-schema.js";
 import {nullTrace} from "../test-utils/null-trace.js";
+
+const ambiguousStep = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - runn: echo hi`;
 
 it("The template is not read when there are YAML errors", () => {
   const content = `
@@ -15,4 +25,23 @@ jobs:
 
   expect(result.context.errors.count).toBe(1);
   expect(result.value).toBeUndefined();
+});
+
+it("omits background step properties from ambiguity errors when disabled", () => {
+  const result = parseWorkflow({name: "main.yaml", content: ambiguousStep}, nullTrace);
+
+  expect(result.context.errors.getErrors().map(x => x.rawMessage)).toContain(
+    "There's not enough info to determine what you meant. Add one of these properties: run, shell, uses, with, working-directory"
+  );
+});
+
+it("includes background step properties in ambiguity errors when enabled", () => {
+  const context = new TemplateContext(new TemplateValidationErrors(), getWorkflowSchema(), nullTrace);
+  context.state.featureFlags = new FeatureFlags({allowBackgroundSteps: true});
+
+  const result = parseWorkflow({name: "main.yaml", content: ambiguousStep}, context);
+
+  expect(result.context.errors.getErrors().map(x => x.rawMessage)).toContain(
+    "There's not enough info to determine what you meant. Add one of these properties: cancel, run, shell, uses, wait, wait-all, with, working-directory"
+  );
 });

--- a/workflow-parser/src/xlang.test.ts
+++ b/workflow-parser/src/xlang.test.ts
@@ -1,15 +1,19 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as YAML from "yaml";
+import {ExperimentalFeatures, FeatureFlags} from "@actions/expressions";
 import {convertWorkflowTemplate} from "./model/convert.js";
+import {TemplateContext, TemplateValidationErrors} from "./templates/template-context.js";
 import {NoOperationTraceWriter} from "./templates/trace-writer.js";
 import {File} from "./workflows/file.js";
 import {FileProvider} from "./workflows/file-provider.js";
 import {fileIdentifier, FileReference} from "./workflows/file-reference.js";
+import {getWorkflowSchema} from "./workflows/workflow-schema.js";
 import {parseWorkflow} from "./workflows/workflow-parser.js";
 
 interface TestOptions {
   "include-source"?: boolean;
+  "experimental-features"?: ExperimentalFeatures;
   skip?: string[];
 }
 
@@ -70,12 +74,16 @@ describe("x-lang tests", () => {
         }
       };
 
+      const featureFlags = new FeatureFlags(testOptions["experimental-features"]);
+      const parseContext = new TemplateContext(new TemplateValidationErrors(), getWorkflowSchema(), nullTrace);
+      parseContext.state.featureFlags = featureFlags;
+
       const parseResult = parseWorkflow(
         {
           name: testFileName,
           content: testInput
         },
-        nullTrace
+        parseContext
       );
 
       expect(parseResult.value).not.toBeUndefined();
@@ -85,7 +93,8 @@ describe("x-lang tests", () => {
         parseResult.value!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
         testFileProvider,
         {
-          fetchReusableWorkflowDepth: 1
+          fetchReusableWorkflowDepth: 1,
+          featureFlags
         }
       );
 

--- a/workflow-parser/testdata/reader/background-steps.yml
+++ b/workflow-parser/testdata/reader/background-steps.yml
@@ -1,0 +1,73 @@
+include-source: false
+experimental-features:
+  allowBackgroundSteps: true
+---
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: server
+        run: npm start
+        background: true
+      - id: checkout
+        uses: actions/checkout@v4
+        background: true
+      - wait:
+          - server
+          - checkout
+      - wait-all:
+      - cancel: server
+---
+{
+  "jobs": [
+    {
+      "type": "job",
+      "id": "build",
+      "name": "build",
+      "if": {
+        "type": 3,
+        "expr": "success()"
+      },
+      "runs-on": "ubuntu-latest",
+      "steps": [
+        {
+          "id": "server",
+          "if": {
+            "type": 3,
+            "expr": "success()"
+          },
+          "run": "npm start",
+          "background": true
+        },
+        {
+          "id": "checkout",
+          "if": {
+            "type": 3,
+            "expr": "success()"
+          },
+          "uses": "actions/checkout@v4",
+          "background": true
+        },
+        {
+          "id": "__wait",
+          "name": "Wait",
+          "wait": [
+            "server",
+            "checkout"
+          ]
+        },
+        {
+          "id": "__wait-all",
+          "name": "Wait for all",
+          "wait-all": true
+        },
+        {
+          "id": "__cancel",
+          "name": "Cancel",
+          "cancel": "server"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This change adds support for the new background step syntax in GitHub Actions workflows.

related to: https://github.com/github/actions-runtime/issues/5506