### PR TITLE
Add concurrency queue support

### DIFF
--- a/expressions/src/features.test.ts
+++ b/expressions/src/features.test.ts
@@ -25,6 +25,7 @@ describe("FeatureFlags", () => {
     it("returns true when all is enabled", () => {
       const flags = new FeatureFlags({all: true});
       expect(flags.isEnabled("missingInputsQuickfix")).toBe(true);
+      expect(flags.isEnabled("allowConcurrencyQueue")).toBe(true);
     });
 
     it("explicit feature flag takes precedence over all:true", () => {
@@ -55,7 +56,8 @@ describe("FeatureFlags", () => {
         "missingInputsQuickfix",
         "blockScalarChompingWarning",
         "allowCaseFunction",
-        "allowCopilotRequestsPermission"
+        "allowCopilotRequestsPermission",
+        "allowConcurrencyQueue"
       ]);
     });
   });

--- a/expressions/src/features.ts
+++ b/expressions/src/features.ts
@@ -40,6 +40,12 @@ export interface ExperimentalFeatures {
    * @default false
    */
   allowCopilotRequestsPermission?: boolean;
+
+  /**
+   * Enable the queue property in workflow concurrency settings.
+   * @default false
+   */
+  allowConcurrencyQueue?: boolean;
 }
 
 /**
@@ -55,7 +61,8 @@ const allFeatureKeys: ExperimentalFeatureKey[] = [
   "missingInputsQuickfix",
   "blockScalarChompingWarning",
   "allowCaseFunction",
-  "allowCopilotRequestsPermission"
+  "allowCopilotRequestsPermission",
+  "allowConcurrencyQueue"
 ];
 
 export class FeatureFlags {

--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -127,6 +127,7 @@ initializationOptions: {
 |---------|-------------|
 | `missingInputsQuickfix` | Code action to add missing required inputs for actions |
 | `blockScalarChompingWarning` | Warn when block scalars (`\|` or `>`) use implicit clip chomping, which adds a trailing newline that may be unintentional |
+| `allowConcurrencyQueue` | Enable the `concurrency.queue` workflow property |
 
 Individual feature flags take precedence over `all`. For example, `{ all: true, missingInputsQuickfix: false }` enables all experimental features except `missingInputsQuickfix`.
 

--- a/languageservice/src/validate.concurrency.test.ts
+++ b/languageservice/src/validate.concurrency.test.ts
@@ -243,3 +243,168 @@ jobs:
     });
   });
 });
+
+describe("validate concurrency queue + cancel-in-progress conflict", () => {
+  describe("should error", () => {
+    it("workflow-level queue: max with cancel-in-progress: true", async () => {
+      const input = `
+on: push
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+  queue: max
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueErrors).toHaveLength(1);
+      expect(queueErrors[0]).toMatchObject({
+        message:
+          "'queue: max' cannot be combined with 'cancel-in-progress: true'.",
+        severity: DiagnosticSeverity.Error
+      });
+    });
+
+    it("job-level queue: max with cancel-in-progress: true", async () => {
+      const input = `
+on: push
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy
+      cancel-in-progress: true
+      queue: max
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueErrors).toHaveLength(1);
+      expect(queueErrors[0]).toMatchObject({
+        severity: DiagnosticSeverity.Error
+      });
+    });
+
+    it("both workflow and job level have the conflict", async () => {
+      const input = `
+on: push
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+  queue: max
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: build
+      cancel-in-progress: true
+      queue: max
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueErrors).toHaveLength(2);
+    });
+  });
+
+  describe("should not error", () => {
+    it("queue: max without cancel-in-progress", async () => {
+      const input = `
+on: push
+concurrency:
+  group: deploy
+  queue: max
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueErrors).toHaveLength(0);
+    });
+
+    it("queue: single with cancel-in-progress: true", async () => {
+      const input = `
+on: push
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+  queue: single
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueErrors).toHaveLength(0);
+    });
+
+    it("cancel-in-progress: false with queue: max", async () => {
+      const input = `
+on: push
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+  queue: max
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueErrors).toHaveLength(0);
+    });
+
+    it("no queue property", async () => {
+      const input = `
+on: push
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueErrors).toHaveLength(0);
+    });
+
+    it("string form concurrency (no mapping)", async () => {
+      const input = `
+on: push
+concurrency: deploy
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueErrors).toHaveLength(0);
+    });
+  });
+});

--- a/languageservice/src/validate.concurrency.test.ts
+++ b/languageservice/src/validate.concurrency.test.ts
@@ -25,7 +25,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(2);
@@ -56,7 +56,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(2);
@@ -77,7 +77,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(2);
@@ -97,7 +97,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(2);
@@ -119,7 +119,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       // Should have 2 warnings per job (workflow + job) = 4 total, but workflow is only warned once per match
       // Actually: 1 workflow warning per matching job + 1 job warning per matching job = 4 total
@@ -140,7 +140,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -157,7 +157,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -174,7 +174,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -190,7 +190,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -206,7 +206,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -223,7 +223,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -241,7 +241,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);

--- a/languageservice/src/validate.concurrency.test.ts
+++ b/languageservice/src/validate.concurrency.test.ts
@@ -1,3 +1,4 @@
+import {FeatureFlags} from "@actions/expressions/features";
 import {DiagnosticSeverity} from "vscode-languageserver-types";
 import {validate} from "./validate.js";
 import {createDocument} from "./test-utils/document.js";
@@ -6,6 +7,10 @@ import {clearCache} from "./utils/workflow-cache.js";
 beforeEach(() => {
   clearCache();
 });
+
+const queueValidationConfig = {
+  featureFlags: new FeatureFlags({allowConcurrencyQueue: true})
+};
 
 describe("validate concurrency deadlock", () => {
   describe("should error on matching concurrency groups", () => {
@@ -20,7 +25,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(2);
@@ -51,7 +56,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(2);
@@ -72,7 +77,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(2);
@@ -92,7 +97,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(2);
@@ -114,7 +119,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       // Should have 2 warnings per job (workflow + job) = 4 total, but workflow is only warned once per match
       // Actually: 1 workflow warning per matching job + 1 job warning per matching job = 4 total
@@ -135,7 +140,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -152,7 +157,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -169,7 +174,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -185,7 +190,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -201,7 +206,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -218,7 +223,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -236,7 +241,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const concurrencyErrors = result.filter(d => d.message.includes("deadlock"));
       expect(concurrencyErrors).toHaveLength(0);
@@ -259,7 +264,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(1);
@@ -282,7 +287,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(1);
@@ -308,7 +313,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input));
+      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
 
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(2);
@@ -404,6 +409,25 @@ jobs:
 
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(0);
+    });
+
+    it("does not report queue conflict when the feature is disabled", async () => {
+      const input = `
+on: push
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+  queue: max
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi`;
+
+      const result = await validate(createDocument("wf.yaml", input));
+
+      const queueConflictErrors = result.filter(d => d.message.includes("queue: max"));
+      expect(queueConflictErrors).toHaveLength(0);
     });
   });
 });

--- a/languageservice/src/validate.concurrency.test.ts
+++ b/languageservice/src/validate.concurrency.test.ts
@@ -264,8 +264,7 @@ jobs:
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(1);
       expect(queueErrors[0]).toMatchObject({
-        message:
-          "'queue: max' cannot be combined with 'cancel-in-progress: true'.",
+        message: "'queue: max' cannot be combined with 'cancel-in-progress: true'.",
         severity: DiagnosticSeverity.Error
       });
     });

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -248,7 +248,9 @@ async function additionalValidations(
   validateConcurrencyDeadlock(diagnostics, template);
 
   // Validate incompatible concurrency options
-  validateConcurrencyQueueCancelInProgress(diagnostics, template);
+  if (featureFlags?.isEnabled("allowConcurrencyQueue")) {
+    validateConcurrencyQueueCancelInProgress(diagnostics, template);
+  }
 }
 
 function invalidValue(diagnostics: Diagnostic[], token: StringToken, kind: ValueProviderKind) {

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -716,8 +716,7 @@ function checkConcurrencyQueueConflict(diagnostics: Diagnostic[], token: Templat
 
   if (hasQueueMax && hasCancelInProgressTrue && queueRange) {
     diagnostics.push({
-      message:
-        "'queue: max' cannot be combined with 'cancel-in-progress: true'.",
+      message: "'queue: max' cannot be combined with 'cancel-in-progress: true'.",
       range: mapRange(queueRange),
       severity: DiagnosticSeverity.Error
     });

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -1,6 +1,13 @@
 import {FeatureFlags, Lexer, Parser} from "@actions/expressions";
 import {Expr} from "@actions/expressions/ast";
-import {TemplateParseResult, WorkflowTemplate, isBasicExpression, isMapping, isString} from "@actions/workflow-parser";
+import {
+  TemplateParseResult,
+  WorkflowTemplate,
+  isBasicExpression,
+  isBoolean,
+  isMapping,
+  isString
+} from "@actions/workflow-parser";
 import {ErrorPolicy} from "@actions/workflow-parser/model/convert";
 import {getCronDescription, hasCronIntervalLessThan5Minutes} from "@actions/workflow-parser/model/converter/cron";
 import {ensureStatusFunction} from "@actions/workflow-parser/model/converter/if-condition";
@@ -239,6 +246,9 @@ async function additionalValidations(
 
   // Validate concurrency deadlock between workflow and job levels
   validateConcurrencyDeadlock(diagnostics, template);
+
+  // Validate incompatible concurrency options
+  validateConcurrencyQueueCancelInProgress(diagnostics, template);
 }
 
 function invalidValue(diagnostics: Diagnostic[], token: StringToken, kind: ValueProviderKind) {
@@ -661,6 +671,56 @@ function validateConcurrencyDeadlock(diagnostics: Diagnostic[], template: Workfl
         });
       }
     }
+  }
+}
+
+/**
+ * Validates that `queue: max` and `cancel-in-progress: true` are not both set
+ * in a concurrency mapping, as this combination is invalid.
+ */
+function validateConcurrencyQueueCancelInProgress(diagnostics: Diagnostic[], template: WorkflowTemplate): void {
+  // Check workflow-level concurrency
+  if (template.concurrency) {
+    checkConcurrencyQueueConflict(diagnostics, template.concurrency);
+  }
+
+  // Check job-level concurrency
+  for (const job of template.jobs || []) {
+    if (job.concurrency) {
+      checkConcurrencyQueueConflict(diagnostics, job.concurrency);
+    }
+  }
+}
+
+function checkConcurrencyQueueConflict(diagnostics: Diagnostic[], token: TemplateToken): void {
+  if (!isMapping(token)) {
+    return;
+  }
+
+  let hasQueueMax = false;
+  let hasCancelInProgressTrue = false;
+  let queueRange: TokenRange | undefined;
+
+  for (const pair of token) {
+    if (!isString(pair.key) || pair.key.isExpression || pair.value.isExpression) {
+      continue;
+    }
+    if (pair.key.value === "queue" && isString(pair.value) && pair.value.value === "max") {
+      hasQueueMax = true;
+      queueRange = pair.key.range;
+    }
+    if (pair.key.value === "cancel-in-progress" && isBoolean(pair.value) && pair.value.value) {
+      hasCancelInProgressTrue = true;
+    }
+  }
+
+  if (hasQueueMax && hasCancelInProgressTrue && queueRange) {
+    diagnostics.push({
+      message:
+        "'queue: max' cannot be combined with 'cancel-in-progress: true'.",
+      range: mapRange(queueRange),
+      severity: DiagnosticSeverity.Error
+    });
   }
 }
 

--- a/workflow-parser/src/model/converter/concurrency.ts
+++ b/workflow-parser/src/model/converter/concurrency.ts
@@ -1,7 +1,7 @@
 import {TemplateContext} from "../../templates/template-context.js";
 import {TemplateToken} from "../../templates/tokens/template-token.js";
 import {isString} from "../../templates/tokens/type-guards.js";
-import {ConcurrencySetting} from "../workflow-template.js";
+import {ConcurrencyQueue, ConcurrencySetting} from "../workflow-template.js";
 
 export function convertConcurrency(context: TemplateContext, token: TemplateToken): ConcurrencySetting {
   const result: ConcurrencySetting = {};
@@ -27,7 +27,7 @@ export function convertConcurrency(context: TemplateContext, token: TemplateToke
         result.cancelInProgress = property.value.assertBoolean("cancel-in-progress").value;
         break;
       case "queue":
-        result.queue = property.value.assertString("queue").value;
+        result.queue = property.value.assertString("queue").value as ConcurrencyQueue;
         break;
       default:
         context.error(propertyName, `Invalid property name: ${propertyName.value}`);

--- a/workflow-parser/src/model/converter/concurrency.ts
+++ b/workflow-parser/src/model/converter/concurrency.ts
@@ -1,3 +1,4 @@
+import type {FeatureFlags} from "@actions/expressions/features";
 import {TemplateContext} from "../../templates/template-context.js";
 import {TemplateToken} from "../../templates/tokens/template-token.js";
 import {isString} from "../../templates/tokens/type-guards.js";
@@ -5,6 +6,7 @@ import {ConcurrencyQueue, ConcurrencySetting} from "../workflow-template.js";
 
 export function convertConcurrency(context: TemplateContext, token: TemplateToken): ConcurrencySetting {
   const result: ConcurrencySetting = {};
+  const featureFlags = context.state.featureFlags as FeatureFlags | undefined;
 
   if (token.isExpression) {
     return result;
@@ -27,7 +29,9 @@ export function convertConcurrency(context: TemplateContext, token: TemplateToke
         result.cancelInProgress = property.value.assertBoolean("cancel-in-progress").value;
         break;
       case "queue":
-        result.queue = property.value.assertString("queue").value as ConcurrencyQueue;
+        if (featureFlags?.isEnabled("allowConcurrencyQueue")) {
+          result.queue = property.value.assertString("queue").value as ConcurrencyQueue;
+        }
         break;
       default:
         context.error(propertyName, `Invalid property name: ${propertyName.value}`);

--- a/workflow-parser/src/model/converter/concurrency.ts
+++ b/workflow-parser/src/model/converter/concurrency.ts
@@ -26,6 +26,9 @@ export function convertConcurrency(context: TemplateContext, token: TemplateToke
       case "cancel-in-progress":
         result.cancelInProgress = property.value.assertBoolean("cancel-in-progress").value;
         break;
+      case "queue":
+        result.queue = property.value.assertString("queue").value;
+        break;
       default:
         context.error(propertyName, `Invalid property name: ${propertyName.value}`);
     }

--- a/workflow-parser/src/model/workflow-template.ts
+++ b/workflow-parser/src/model/workflow-template.ts
@@ -21,6 +21,7 @@ export type WorkflowTemplate = {
 export type ConcurrencySetting = {
   group?: StringToken;
   cancelInProgress?: boolean;
+  queue?: string;
 };
 
 export type ActionsEnvironmentReference = {

--- a/workflow-parser/src/model/workflow-template.ts
+++ b/workflow-parser/src/model/workflow-template.ts
@@ -18,10 +18,12 @@ export type WorkflowTemplate = {
   }[];
 };
 
+export type ConcurrencyQueue = "single" | "max";
+
 export type ConcurrencySetting = {
   group?: StringToken;
   cancelInProgress?: boolean;
-  queue?: string;
+  queue?: ConcurrencyQueue;
 };
 
 export type ActionsEnvironmentReference = {

--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -2050,9 +2050,19 @@
           "cancel-in-progress": {
             "type": "boolean",
             "description": "To cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true."
+          },
+          "queue": {
+            "type": "concurrency-queue",
+            "description": "The queuing mode for the concurrency group. When set to `max`, workflows or jobs will wait in a queue for the concurrency group up to the maximum queue length. Default: `single` meaning at most one item can be pending."
           }
         }
       }
+    },
+    "concurrency-queue": {
+      "allowed-values": [
+        "single",
+        "max"
+      ]
     },
     "job-environment": {
       "description": "The environment that the job references. All environment protection rules must pass before a job referencing the environment is sent to a runner.",

--- a/workflow-parser/testdata/reader/concurrency.yml
+++ b/workflow-parser/testdata/reader/concurrency.yml
@@ -25,7 +25,11 @@ jobs:
     concurrency:
       group: ref
       cancel-in-progress: ${{ github.ref }}
-
+  build5:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy
+      queue: max
 
 ---
 {
@@ -141,6 +145,29 @@ jobs:
         ]
       },
       "runs-on": "macos-latest"
+    },
+    {
+      "type": "job",
+      "id": "build5",
+      "name": "build5",
+      "if": {
+        "type": 3,
+        "expr": "success()"
+      },
+      "concurrency": {
+        "type": 2,
+        "map": [
+          {
+            "Key": "group",
+            "Value": "deploy"
+          },
+          {
+            "Key": "queue",
+            "Value": "max"
+          }
+        ]
+      },
+      "runs-on": "ubuntu-latest"
     }
   ]
 }


### PR DESCRIPTION
## Add `queue` property to concurrency groups

### Summary

Adds support for a new optional `queue` property in the `concurrency` mapping, at both workflow and job levels. This enables workflows or jobs to wait in a queue for a concurrency group up to the maximum queue length, rather than the default behavior that allows only a single pending item.

### Valid values

- `single` (default) — existing behavior; only one pending run per concurrency group
- `max` — pending runs queue up to the maximum queue length

### Validation

The language service detects and reports an error when `queue: max` is combined with `cancel-in-progress: true`, since a concurrency group cannot both queue waiting runs and cancel ones in progess. (This combination is also blocked at runtime, not only in language services.)

### Changes

**Schema & parser** (workflow-parser)
- Added `queue` property to `concurrency-mapping` in the workflow schema
- Added `concurrency-queue` definition with `allowed-values: ["single", "max"]`
- Added `queue` field to the `ConcurrencySetting` type
- Updated the concurrency converter to extract the `queue` value
- Added parser test data with `queue: max`

**Language service** (languageservice)
- Added validation for the `queue: max` + `cancel-in-progress: true` conflict
- Added 8 tests covering the new validation (error and no-error cases)

### Example usage

```yaml
concurrency:
  group: deploy-${{ github.ref }}
  queue: max
```

```yaml
# This is invalid and will produce an error:
concurrency:
  group: deploy
  cancel-in-progress: true
  queue: max
```