### PR TITLE
Add vulnerability-alerts permission to workflow schema

### DIFF
--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -1644,11 +1644,15 @@
           },
           "security-events": {
             "type": "permission-level-any",
-            "description": "Code scanning and Dependabot alerts."
+            "description": "Code scanning alerts."
           },
           "statuses": {
             "type": "permission-level-any",
             "description": "Commit statuses."
+          },
+          "vulnerability-alerts": {
+            "type": "permission-level-read-or-no-access",
+            "description": "Dependabot alerts."
           }
         }
       }


### PR DESCRIPTION
## Summary

Add `vulnerability-alerts` as a new read-only permission key in the workflow schema permissions-mapping.

## Changes
- Added `vulnerability-alerts` with `permission-level-read-or-no-access` type (only `read` and `none` are valid)
- Updated `security-events` description to `Code scanning alerts.` (Dependabot alerts now have their own key)