### PR TITLE
Revert "Add field_added and field_removed issue event types to workflows (#351)"

### DIFF
--- a/languageservice/src/complete.test.ts
+++ b/languageservice/src/complete.test.ts
@@ -112,19 +112,6 @@ jobs:
     ]);
   });
 
-  it("issues activity type completion includes field_added and field_removed", async () => {
-    const input = `on:
-  issues:
-    types:
-      - |`;
-    const result = await complete(...getPositionFromCursor(input));
-    const labels = result.map(x => x.label);
-    expect(labels).toContain("field_added");
-    expect(labels).toContain("field_removed");
-    expect(labels).toContain("opened");
-    expect(labels).toContain("closed");
-  });
-
   it("map keys filter out existing values", async () => {
     const input = `on: push
 jobs:

--- a/languageservice/src/validate.test.ts
+++ b/languageservice/src/validate.test.ts
@@ -165,43 +165,6 @@ jobs:
     } as Diagnostic);
   });
 
-  it("issues event with field_added activity type", async () => {
-    const result = await validate(
-      createDocument(
-        "wf.yaml",
-        `on:
-  issues:
-    types: [field_added, field_removed]
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - run: echo`
-      )
-    );
-
-    expect(result.length).toBe(0);
-  });
-
-  it("issues event with invalid activity type", async () => {
-    const result = await validate(
-      createDocument(
-        "wf.yaml",
-        `on:
-  issues:
-    types: [opened, not_a_real_type]
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - run: echo`
-      )
-    );
-
-    expect(result.length).toBe(1);
-    expect(result[0]?.message).toBe("Unexpected value 'not_a_real_type'");
-  });
-
   it("invalid cron string", async () => {
     const result = await validate(
       createDocument(

--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -539,7 +539,7 @@
       }
     },
     "issues-activity": {
-      "description": "The types of issue activity that trigger the workflow. Supported activity types: `opened`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `closed`, `reopened`, `assigned`, `unassigned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `milestoned`, `demilestoned`, `field_added`, `field_removed`.",
+      "description": "The types of issue activity that trigger the workflow. Supported activity types: `opened`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `closed`, `reopened`, `assigned`, `unassigned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `milestoned`, `demilestoned`.",
       "one-of": [
         "issues-activity-type",
         "issues-activity-types"
@@ -567,9 +567,7 @@
         "locked",
         "unlocked",
         "milestoned",
-        "demilestoned",
-        "field_added",
-        "field_removed"
+        "demilestoned"
       ]
     },
     "label-string": {

--- a/workflow-parser/testdata/reader/events-mapping-all.yml
+++ b/workflow-parser/testdata/reader/events-mapping-all.yml
@@ -66,8 +66,6 @@ on:
       - unlocked
       - milestoned
       - demilestoned
-      - field_added
-      - field_removed
   label:
     types:
       - created
@@ -318,9 +316,7 @@ jobs:
         "locked",
         "unlocked",
         "milestoned",
-        "demilestoned",
-        "field_added",
-        "field_removed"
+        "demilestoned"
       ]
     },
     "label": {


### PR DESCRIPTION
Reverts the schema change from #351. These activity types are not in the upstream OpenAPI spec (`rest-api-description`), which causes the schema-sync test to fail. The upstream spec needs to be updated first before re-adding these.