### PR TITLE
Add parallel syntax support

### DIFF
--- a/languageservice/src/complete.ts
+++ b/languageservice/src/complete.ts
@@ -42,7 +42,7 @@ import {Value, ValueProviderConfig} from "./value-providers/config.js";
 import {defaultValueProviders} from "./value-providers/default.js";
 import {DefinitionValueMode, definitionValues, TokenStructure} from "./value-providers/definition.js";
 
-const backgroundStepCompletionLabels = new Set(["background", "wait", "wait-all", "cancel"]);
+const backgroundStepCompletionLabels = new Set(["background", "wait", "wait-all", "cancel", "parallel"]);
 
 export function getExpressionInput(input: string, pos: number): string {
   // Find start marker around the cursor position

--- a/languageservice/src/validate.test.ts
+++ b/languageservice/src/validate.test.ts
@@ -85,7 +85,7 @@ jobs:
     );
 
     expect(result.map(x => x.message)).toContain(
-      "There's not enough info to determine what you meant. Add one of these properties: cancel, run, shell, uses, wait, wait-all, with, working-directory"
+      "There's not enough info to determine what you meant. Add one of these properties: cancel, parallel, run, shell, uses, wait, wait-all, with, working-directory"
     );
   });
 

--- a/workflow-parser/src/model/convert.test.ts
+++ b/workflow-parser/src/model/convert.test.ts
@@ -768,7 +768,7 @@ jobs:
       });
 
       expect(template.errors).toBeUndefined();
-      const job = template.jobs![0];
+      const job = template.jobs[0];
       expect("steps" in job).toBe(true);
       if (!("steps" in job)) return;
       expect(job.steps).toHaveLength(1);

--- a/workflow-parser/src/model/convert.test.ts
+++ b/workflow-parser/src/model/convert.test.ts
@@ -741,4 +741,129 @@ jobs:
       });
     });
   });
+
+  describe("parallel steps", () => {
+    it("converts a valid parallel block", async () => {
+      const context = new TemplateContext(new TemplateValidationErrors(), getWorkflowSchema(), nullTrace);
+      context.state.featureFlags = new FeatureFlags({allowBackgroundSteps: true});
+
+      const result = parseWorkflow(
+        {
+          name: "wf.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - run: echo "step 1"
+          - run: echo "step 2"`
+        },
+        context
+      );
+
+      const template = await convertWorkflowTemplate(result.context, result.value!, undefined, {
+        errorPolicy: ErrorPolicy.TryConversion,
+        featureFlags: new FeatureFlags({allowBackgroundSteps: true})
+      });
+
+      expect(template.errors).toBeUndefined();
+      const job = template.jobs![0] as {steps: unknown[]};
+      expect(job.steps).toHaveLength(1);
+      expect(job.steps[0]).toHaveProperty("parallel");
+      const parallelStep = job.steps[0] as {parallel: unknown[]};
+      expect(parallelStep.parallel).toHaveLength(2);
+    });
+
+    it("rejects wait inside parallel block", async () => {
+      const context = new TemplateContext(new TemplateValidationErrors(), getWorkflowSchema(), nullTrace);
+      context.state.featureFlags = new FeatureFlags({allowBackgroundSteps: true});
+
+      const result = parseWorkflow(
+        {
+          name: "wf.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: bg
+        run: echo hi
+        background: true
+      - parallel:
+          - wait: bg
+          - run: echo "step 1"`
+        },
+        context
+      );
+
+      const template = await convertWorkflowTemplate(result.context, result.value!, undefined, {
+        errorPolicy: ErrorPolicy.TryConversion,
+        featureFlags: new FeatureFlags({allowBackgroundSteps: true})
+      });
+
+      expect(template.errors).toBeDefined();
+      expect(template.errors!.some(e => e.Message.includes("'wait' is not allowed inside a parallel block"))).toBe(
+        true
+      );
+    });
+
+    it("rejects background inside parallel block", async () => {
+      const context = new TemplateContext(new TemplateValidationErrors(), getWorkflowSchema(), nullTrace);
+      context.state.featureFlags = new FeatureFlags({allowBackgroundSteps: true});
+
+      const result = parseWorkflow(
+        {
+          name: "wf.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - run: echo hi
+            background: true`
+        },
+        context
+      );
+
+      const template = await convertWorkflowTemplate(result.context, result.value!, undefined, {
+        errorPolicy: ErrorPolicy.TryConversion,
+        featureFlags: new FeatureFlags({allowBackgroundSteps: true})
+      });
+
+      expect(template.errors).toBeDefined();
+      expect(
+        template.errors!.some(e => e.Message.includes("'background' is not allowed inside a parallel block"))
+      ).toBe(true);
+    });
+
+    it("rejects nested parallel blocks", async () => {
+      const context = new TemplateContext(new TemplateValidationErrors(), getWorkflowSchema(), nullTrace);
+      context.state.featureFlags = new FeatureFlags({allowBackgroundSteps: true});
+
+      const result = parseWorkflow(
+        {
+          name: "wf.yaml",
+          content: `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - parallel:
+          - parallel:
+              - run: echo nested`
+        },
+        context
+      );
+
+      const template = await convertWorkflowTemplate(result.context, result.value!, undefined, {
+        errorPolicy: ErrorPolicy.TryConversion,
+        featureFlags: new FeatureFlags({allowBackgroundSteps: true})
+      });
+
+      expect(template.errors).toBeDefined();
+      expect(template.errors!.some(e => e.Message.includes("Nested 'parallel' blocks are not allowed"))).toBe(true);
+    });
+  });
 });

--- a/workflow-parser/src/model/convert.test.ts
+++ b/workflow-parser/src/model/convert.test.ts
@@ -768,7 +768,9 @@ jobs:
       });
 
       expect(template.errors).toBeUndefined();
-      const job = template.jobs![0] as {steps: unknown[]};
+      const job = template.jobs![0];
+      expect("steps" in job).toBe(true);
+      if (!("steps" in job)) return;
       expect(job.steps).toHaveLength(1);
       expect(job.steps[0]).toHaveProperty("parallel");
       const parallelStep = job.steps[0] as {parallel: unknown[]};

--- a/workflow-parser/src/model/converter/steps.ts
+++ b/workflow-parser/src/model/converter/steps.ts
@@ -48,6 +48,8 @@ export function convertSteps(context: TemplateContext, steps: TemplateToken): St
       id = "wait-all";
     } else if ("cancel" in step) {
       id = "cancel";
+    } else if ("parallel" in step) {
+      id = "parallel";
     }
 
     if (!id) {
@@ -77,6 +79,7 @@ function convertStep(
   let wait: StringToken[] | undefined;
   let waitAll: boolean | undefined;
   let cancel: StringToken | undefined;
+  let parallel: TemplateToken | undefined;
   let continueOnError: boolean | ScalarToken | undefined;
   let env: MappingToken | undefined;
   let ifCondition: BasicExpressionToken | undefined;
@@ -115,6 +118,9 @@ function convertStep(
       case "cancel":
         cancel = item.value.assertString("steps item cancel");
         validateTargetStepId(context, knownStepIds, cancel, id);
+        break;
+      case "parallel":
+        parallel = item.value;
         break;
       case "env":
         env = item.value.assertMapping("step env");
@@ -181,10 +187,38 @@ function convertStep(
       cancel
     };
   }
+
+  if (parallel) {
+    const parallelSteps = convertSteps(context, parallel);
+    // Validate: parallel blocks only allow run and uses steps
+    for (const ps of parallelSteps) {
+      if ("background" in ps && ps.background) {
+        context.error(step, "'background: true' is not allowed inside a parallel block. Steps in a parallel block are automatically run as background steps.");
+      }
+      if ("wait" in ps) {
+        context.error(step, "'wait' is not allowed inside a parallel block.");
+      }
+      if ("wait-all" in ps) {
+        context.error(step, "'wait-all' is not allowed inside a parallel block.");
+      }
+      if ("cancel" in ps) {
+        context.error(step, "'cancel' is not allowed inside a parallel block.");
+      }
+      if ("parallel" in ps) {
+        context.error(step, "Nested 'parallel' blocks are not allowed.");
+      }
+    }
+    return {
+      id: id?.value || "",
+      name: name || createSyntheticStepName("Parallel group"),
+      parallel: parallelSteps
+    };
+  }
+
   context.error(
     step,
     (context.state.featureFlags as FeatureFlags | undefined)?.isEnabled("allowBackgroundSteps")
-      ? "Expected one of uses, run, wait, wait-all, or cancel to be defined"
+      ? "Expected one of uses, run, wait, wait-all, cancel, or parallel to be defined"
       : "Expected one of uses or run to be defined"
   );
 }

--- a/workflow-parser/src/model/converter/steps.ts
+++ b/workflow-parser/src/model/converter/steps.ts
@@ -192,8 +192,11 @@ function convertStep(
     const parallelSteps = convertSteps(context, parallel);
     // Validate: parallel blocks only allow run and uses steps
     for (const ps of parallelSteps) {
-      if ("background" in ps && ps.background) {
-        context.error(step, "'background: true' is not allowed inside a parallel block. Steps in a parallel block are automatically run as background steps.");
+      if ("background" in ps && ps.background !== undefined) {
+        context.error(
+          step,
+          "'background' is not allowed inside a parallel block. Steps in a parallel block are automatically run as background steps."
+        );
       }
       if ("wait" in ps) {
         context.error(step, "'wait' is not allowed inside a parallel block.");

--- a/workflow-parser/src/model/workflow-template.ts
+++ b/workflow-parser/src/model/workflow-template.ts
@@ -87,7 +87,7 @@ export type Credential = {
   password: StringToken | undefined;
 };
 
-export type Step = ActionStep | RunStep | WaitStep | WaitAllStep | CancelStep;
+export type Step = ActionStep | RunStep | WaitStep | WaitAllStep | CancelStep | ParallelStep;
 
 type BaseStep = {
   id: string;
@@ -121,6 +121,10 @@ export type WaitAllStep = BaseStep & {
 
 export type CancelStep = BaseStep & {
   cancel: StringToken;
+};
+
+export type ParallelStep = BaseStep & {
+  parallel: Step[];
 };
 
 export type EventsConfig = {

--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -2165,7 +2165,8 @@
         "regular-step",
         "wait-step",
         "wait-all-step",
-        "cancel-step"
+        "cancel-step",
+        "parallel-step"
       ]
     },
     "run-step": {
@@ -2243,6 +2244,22 @@
             "required": true
           }
         }
+      }
+    },
+    "parallel-step": {
+      "mapping": {
+        "properties": {
+          "parallel": {
+            "type": "parallel-steps",
+            "required": true,
+            "description": "Run a group of steps concurrently. All steps in the parallel block run as background steps and the workflow waits for all of them to complete before continuing."
+          }
+        }
+      }
+    },
+    "parallel-steps": {
+      "sequence": {
+        "item-type": "steps-item"
       }
     },
     "step-uses": {

--- a/workflow-parser/src/workflows/workflow-parser.test.ts
+++ b/workflow-parser/src/workflows/workflow-parser.test.ts
@@ -31,7 +31,7 @@ it("omits background step properties from ambiguity errors when disabled", () =>
   const result = parseWorkflow({name: "main.yaml", content: ambiguousStep}, nullTrace);
 
   expect(result.context.errors.getErrors().map(x => x.rawMessage)).toContain(
-    "There's not enough info to determine what you meant. Add one of these properties: run, shell, uses, with, working-directory"
+    "There's not enough info to determine what you meant. Add one of these properties: parallel, run, shell, uses, with, working-directory"
   );
 });
 
@@ -42,6 +42,6 @@ it("includes background step properties in ambiguity errors when enabled", () =>
   const result = parseWorkflow({name: "main.yaml", content: ambiguousStep}, context);
 
   expect(result.context.errors.getErrors().map(x => x.rawMessage)).toContain(
-    "There's not enough info to determine what you meant. Add one of these properties: cancel, run, shell, uses, wait, wait-all, with, working-directory"
+    "There's not enough info to determine what you meant. Add one of these properties: cancel, parallel, run, shell, uses, wait, wait-all, with, working-directory"
   );
 });

--- a/workflow-parser/testdata/reader/error.yml
+++ b/workflow-parser/testdata/reader/error.yml
@@ -14,7 +14,7 @@ jobs:
       "Message": ".github/workflows/error.yml (Line: 7, Col: 9): Unexpected value 'runn'"
     },
     {
-      "Message": ".github/workflows/error.yml (Line: 7, Col: 9): There's not enough info to determine what you meant. Add one of these properties: run, shell, uses, with, working-directory"
+      "Message": ".github/workflows/error.yml (Line: 7, Col: 9): There's not enough info to determine what you meant. Add one of these properties: parallel, run, shell, uses, with, working-directory"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds `parallel:` syntax support to the workflow parser and language service.
