### PR TITLE
fix: handle undefined initializationOptions in LSP params

### DIFF
--- a/languageserver/src/connection.ts
+++ b/languageserver/src/connection.ts
@@ -62,7 +62,7 @@ export function initConnection(connection: Connection) {
 
     hasWorkspaceFolderCapability = !!(capabilities.workspace && !!capabilities.workspace.workspaceFolders);
 
-    const options = params.initializationOptions as InitializationOptions;
+    const options = (params.initializationOptions ?? {}) as InitializationOptions;
 
     if (options.sessionToken) {
       client = getClient(options.sessionToken, options.userAgent, options.gitHubApiUrl);


### PR DESCRIPTION
## Overview
This change handles the case where `initializationOptions` is optional and may be `undefined`, ensuring safe access by providing a default value.

## Changes

```ts
// Before
const options = params.initializationOptions as InitializationOptions;

// After
const options = (params.initializationOptions ?? {}) as InitializationOptions;
```

## Background
When running via CLI, a runtime error occurred
```
Server initialization failed.
Message: Request initialize failed with message: Cannot read properties of undefined (reading 'sessionToken')
```