### PR TITLE
Add Homebrew as an alternate installation method

### DIFF
--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -10,10 +10,16 @@ The [package](https://www.npmjs.com/package/@actions/languageserver) contains Ty
 npm install @actions/languageserver
 ```
 
-To install the language server as a standalone CLI:
+To install the language server as a standalone CLI with [NPM](https://github.com/actions/languageservices):
 
 ```bash
 npm install -g @actions/languageserver
+```
+
+Alternatively, you can install it using [Homebrew](https://brew.sh):
+
+```bash
+brew install actions-languageserver
 ```
 
 This makes the `actions-languageserver` command available globally.


### PR DESCRIPTION
Separate the instructions for installing with NPM or [Homebrew](https://github.com/Homebrew/homebrew-core/commit/6c62c29a0349dc0e85feee24566fbd658c1f0a7c).