### PR TITLE
Graduate concurrency queue feature in workflow language service

### DIFF
--- a/expressions/src/features.test.ts
+++ b/expressions/src/features.test.ts
@@ -25,7 +25,6 @@ describe("FeatureFlags", () => {
     it("returns true when all is enabled", () => {
       const flags = new FeatureFlags({all: true});
       expect(flags.isEnabled("missingInputsQuickfix")).toBe(true);
-      expect(flags.isEnabled("allowConcurrencyQueue")).toBe(true);
     });
 
     it("explicit feature flag takes precedence over all:true", () => {
@@ -58,7 +57,6 @@ describe("FeatureFlags", () => {
         "allowCaseFunction",
         "allowCopilotRequestsPermission",
         "allowDrivesPermissionAutocomplete",
-        "allowConcurrencyQueue",
         "allowBackgroundSteps"
       ]);
     });

--- a/expressions/src/features.ts
+++ b/expressions/src/features.ts
@@ -49,7 +49,9 @@ export interface ExperimentalFeatures {
 
   /**
    * Enable the queue property in workflow concurrency settings.
-   * @default false
+   *
+   * @deprecated Graduated to stable — the queue property is always enabled
+   * regardless of this value.
    */
   allowConcurrencyQueue?: boolean;
 

--- a/expressions/src/features.ts
+++ b/expressions/src/features.ts
@@ -48,14 +48,6 @@ export interface ExperimentalFeatures {
   allowDrivesPermissionAutocomplete?: boolean;
 
   /**
-   * Enable the queue property in workflow concurrency settings.
-   *
-   * @deprecated Graduated to stable — the queue property is always enabled
-   * regardless of this value.
-   */
-  allowConcurrencyQueue?: boolean;
-
-  /**
    * Enable background workflow steps and related wait/cancel steps.
    * @default false
    */
@@ -77,7 +69,6 @@ const allFeatureKeys: ExperimentalFeatureKey[] = [
   "allowCaseFunction",
   "allowCopilotRequestsPermission",
   "allowDrivesPermissionAutocomplete",
-  "allowConcurrencyQueue",
   "allowBackgroundSteps"
 ];
 

--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -127,7 +127,6 @@ initializationOptions: {
 |---------|-------------|
 | `missingInputsQuickfix` | Code action to add missing required inputs for actions |
 | `blockScalarChompingWarning` | Warn when block scalars (`\|` or `>`) use implicit clip chomping, which adds a trailing newline that may be unintentional |
-| `allowConcurrencyQueue` | Enable the `concurrency.queue` workflow property |
 | `allowBackgroundSteps` | Enable background workflow steps and related wait/cancel steps |
 
 Individual feature flags take precedence over `all`. For example, `{ all: true, missingInputsQuickfix: false }` enables all experimental features except `missingInputsQuickfix`.

--- a/languageservice/src/validate.concurrency.test.ts
+++ b/languageservice/src/validate.concurrency.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 });
 
 const queueValidationConfig = {
-  featureFlags: new FeatureFlags({allowConcurrencyQueue: true})
+  featureFlags: new FeatureFlags({})
 };
 
 describe("validate concurrency deadlock", () => {
@@ -409,25 +409,6 @@ jobs:
 
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(0);
-    });
-
-    it("does not report queue conflict when the feature is disabled", async () => {
-      const input = `
-on: push
-concurrency:
-  group: deploy
-  cancel-in-progress: true
-  queue: max
-jobs:
-  job1:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo hi`;
-
-      const result = await validate(createDocument("wf.yaml", input));
-
-      const queueConflictErrors = result.filter(d => d.message.includes("queue: max"));
-      expect(queueConflictErrors).toHaveLength(0);
     });
   });
 });

--- a/languageservice/src/validate.concurrency.test.ts
+++ b/languageservice/src/validate.concurrency.test.ts
@@ -1,4 +1,3 @@
-import {FeatureFlags} from "@actions/expressions/features";
 import {DiagnosticSeverity} from "vscode-languageserver-types";
 import {validate} from "./validate.js";
 import {createDocument} from "./test-utils/document.js";
@@ -7,10 +6,6 @@ import {clearCache} from "./utils/workflow-cache.js";
 beforeEach(() => {
   clearCache();
 });
-
-const queueValidationConfig = {
-  featureFlags: new FeatureFlags({})
-};
 
 describe("validate concurrency deadlock", () => {
   describe("should error on matching concurrency groups", () => {
@@ -264,7 +259,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(1);
@@ -287,7 +282,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(1);
@@ -313,7 +308,7 @@ jobs:
     steps:
       - run: echo hi`;
 
-      const result = await validate(createDocument("wf.yaml", input), queueValidationConfig);
+      const result = await validate(createDocument("wf.yaml", input));
 
       const queueErrors = result.filter(d => d.message.includes("queue: max"));
       expect(queueErrors).toHaveLength(2);

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -253,9 +253,7 @@ async function additionalValidations(
   validateConcurrencyDeadlock(diagnostics, template);
 
   // Validate incompatible concurrency options
-  if (featureFlags?.isEnabled("allowConcurrencyQueue")) {
-    validateConcurrencyQueueCancelInProgress(diagnostics, template);
-  }
+  validateConcurrencyQueueCancelInProgress(diagnostics, template);
 }
 
 function invalidValue(diagnostics: Diagnostic[], token: StringToken, kind: ValueProviderKind) {

--- a/workflow-parser/src/model/converter/concurrency.ts
+++ b/workflow-parser/src/model/converter/concurrency.ts
@@ -1,4 +1,3 @@
-import type {FeatureFlags} from "@actions/expressions/features";
 import {TemplateContext} from "../../templates/template-context.js";
 import {TemplateToken} from "../../templates/tokens/template-token.js";
 import {isString} from "../../templates/tokens/type-guards.js";
@@ -6,7 +5,6 @@ import {ConcurrencyQueue, ConcurrencySetting} from "../workflow-template.js";
 
 export function convertConcurrency(context: TemplateContext, token: TemplateToken): ConcurrencySetting {
   const result: ConcurrencySetting = {};
-  const featureFlags = context.state.featureFlags as FeatureFlags | undefined;
 
   if (token.isExpression) {
     return result;
@@ -29,9 +27,7 @@ export function convertConcurrency(context: TemplateContext, token: TemplateToke
         result.cancelInProgress = property.value.assertBoolean("cancel-in-progress").value;
         break;
       case "queue":
-        if (featureFlags?.isEnabled("allowConcurrencyQueue")) {
-          result.queue = property.value.assertString("queue").value as ConcurrencyQueue;
-        }
+        result.queue = property.value.assertString("queue").value as ConcurrencyQueue;
         break;
       default:
         context.error(propertyName, `Invalid property name: ${propertyName.value}`);


### PR DESCRIPTION
 - Mark the `ExperimentalFeatures.allowConcurrencyQueue` flag as `@deprecated`.
 - Remove conditional logic that checked the flag, so that the `queue` property is always enabled in the language service.