### PR TITLE
resolve permissions: drives

### DIFF
--- a/expressions/src/features.test.ts
+++ b/expressions/src/features.test.ts
@@ -57,6 +57,7 @@ describe("FeatureFlags", () => {
         "blockScalarChompingWarning",
         "allowCaseFunction",
         "allowCopilotRequestsPermission",
+        "allowDrivesPermissionAutocomplete",
         "allowConcurrencyQueue",
         "allowBackgroundSteps"
       ]);

--- a/expressions/src/features.ts
+++ b/expressions/src/features.ts
@@ -42,6 +42,12 @@ export interface ExperimentalFeatures {
   allowCopilotRequestsPermission?: boolean;
 
   /**
+   * Enable the drives permission in workflow permissions autocomplete.
+   * @default false
+   */
+  allowDrivesPermissionAutocomplete?: boolean;
+
+  /**
    * Enable the queue property in workflow concurrency settings.
    * @default false
    */
@@ -68,6 +74,7 @@ const allFeatureKeys: ExperimentalFeatureKey[] = [
   "blockScalarChompingWarning",
   "allowCaseFunction",
   "allowCopilotRequestsPermission",
+  "allowDrivesPermissionAutocomplete",
   "allowConcurrencyQueue",
   "allowBackgroundSteps"
 ];

--- a/languageservice/src/complete.test.ts
+++ b/languageservice/src/complete.test.ts
@@ -1045,6 +1045,82 @@ jobs:
   });
 });
 
+describe("permissions drives completion", () => {
+  it("includes drives when allowDrivesPermissionAutocomplete is enabled", async () => {
+    const input = `on: push
+permissions:
+  |`;
+    const result = await complete(...getPositionFromCursor(input), {
+      featureFlags: new FeatureFlags({allowDrivesPermissionAutocomplete: true})
+    });
+
+    expect(result).not.toBeUndefined();
+    const labels = result.map(x => x.label);
+    expect(labels).toContain("actions");
+    expect(labels).toContain("drives");
+  });
+
+  it("excludes drives when allowDrivesPermissionAutocomplete is disabled", async () => {
+    const input = `on: push
+permissions:
+  |`;
+    const result = await complete(...getPositionFromCursor(input), {
+      featureFlags: new FeatureFlags({allowDrivesPermissionAutocomplete: false})
+    });
+
+    expect(result).not.toBeUndefined();
+    const labels = result.map(x => x.label);
+    expect(labels).toContain("actions");
+    expect(labels).not.toContain("drives");
+  });
+
+  it("excludes drives when no feature flags are provided", async () => {
+    const input = `on: push
+permissions:
+  |`;
+    const result = await complete(...getPositionFromCursor(input));
+
+    expect(result).not.toBeUndefined();
+    const labels = result.map(x => x.label);
+    expect(labels).toContain("actions");
+    expect(labels).not.toContain("drives");
+  });
+
+  it("includes drives in job-level permissions when allowDrivesPermissionAutocomplete is enabled", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      |`;
+    const result = await complete(...getPositionFromCursor(input), {
+      featureFlags: new FeatureFlags({allowDrivesPermissionAutocomplete: true})
+    });
+
+    expect(result).not.toBeUndefined();
+    const labels = result.map(x => x.label);
+    expect(labels).toContain("actions");
+    expect(labels).toContain("drives");
+  });
+
+  it("excludes drives from job-level permissions when allowDrivesPermissionAutocomplete is disabled", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      |`;
+    const result = await complete(...getPositionFromCursor(input), {
+      featureFlags: new FeatureFlags({allowDrivesPermissionAutocomplete: false})
+    });
+
+    expect(result).not.toBeUndefined();
+    const labels = result.map(x => x.label);
+    expect(labels).toContain("actions");
+    expect(labels).not.toContain("drives");
+  });
+});
+
 describe("service container command/entrypoint completion", () => {
   it("suggests entrypoint and command in service container", async () => {
     const input = `on: push

--- a/languageservice/src/complete.ts
+++ b/languageservice/src/complete.ts
@@ -174,6 +174,14 @@ export async function complete(
     values = values.filter(v => v.label !== "copilot-requests");
   }
 
+  // Filter `drives` from permissions completions when the feature flag is disabled
+  if (
+    !config?.featureFlags?.isEnabled("allowDrivesPermissionAutocomplete") &&
+    parent?.definition?.key === "permissions-mapping"
+  ) {
+    values = values.filter(v => v.label !== "drives");
+  }
+
   if (!isAction && !config?.featureFlags?.isEnabled("allowBackgroundSteps")) {
     values = values.filter(v => !backgroundStepCompletionLabels.has(v.label));
   }

--- a/workflow-parser/src/workflow-v1.0.json
+++ b/workflow-parser/src/workflow-v1.0.json
@@ -1622,6 +1622,10 @@
             "type": "permission-level-any",
             "description": "Discussions and related comments and labels."
           },
+          "drives": {
+            "type": "permission-level-any",
+            "description": "GitHub Drives persistent workspace storage. Use `read` for checkout and `write` to commit changes."
+          },
           "id-token": {
             "type": "permission-level-write-or-no-access",
             "description": "Token to request an OpenID Connect token."


### PR DESCRIPTION
This adds the drives workflow permission to the schema so it validates cleanly, while keeping it hidden from autocomplete until GA.

Gated behind the `allowDrivesPermissionAutocomplete` ff. 