### PR TITLE
Accept $/ self repository uses syntax (steps + reusable workflows)

### DIFF
--- a/languageservice/src/action.test.ts
+++ b/languageservice/src/action.test.ts
@@ -59,6 +59,10 @@ describe("parseActionReference", () => {
     expect(parse("./directory/")).toBeUndefined();
   });
 
+  it("self-reference action", () => {
+    expect(parse("$/actions/composite")).toBeUndefined();
+  });
+
   it("Docker Hub action", () => {
     expect(parse("docker://alpine:3.8")).toBeUndefined();
   });

--- a/languageservice/src/action.test.ts
+++ b/languageservice/src/action.test.ts
@@ -59,7 +59,7 @@ describe("parseActionReference", () => {
     expect(parse("./directory/")).toBeUndefined();
   });
 
-  it("self-reference action", () => {
+  it("self repository action", () => {
     expect(parse("$/actions/composite")).toBeUndefined();
   });
 

--- a/languageservice/src/action.ts
+++ b/languageservice/src/action.ts
@@ -33,7 +33,13 @@ export type ActionReference = {
 
 // https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses
 export function parseActionReference(uses: string): ActionReference | undefined {
-  if (!uses || uses.startsWith("docker://") || uses.startsWith("./") || uses.startsWith(".\\")) {
+  if (
+    !uses ||
+    uses.startsWith("docker://") ||
+    uses.startsWith("./") ||
+    uses.startsWith(".\\") ||
+    uses.startsWith("$/")
+  ) {
     return undefined;
   }
 

--- a/languageservice/src/utils/validate-uses.ts
+++ b/languageservice/src/utils/validate-uses.ts
@@ -68,8 +68,8 @@ export function validateStepUsesFormat(diagnostics: Diagnostic[], token: StringT
   }
 
   // Self-reference ($/path): an action resolved from the same repository as the
-  // currently-executing workflow/action. No version (@ref) is allowed since the ref is
-  // implicitly the same as the executing workflow/action.
+  // currently-executing workflow/action. A trailing @ref is accepted (and ignored), matching
+  // the runtime parser and the rest of the tooling fleet.
   if (uses.startsWith("$/")) {
     validateSelfUsesFormat(diagnostics, token, uses);
     return;

--- a/languageservice/src/utils/validate-uses.ts
+++ b/languageservice/src/utils/validate-uses.ts
@@ -62,16 +62,8 @@ export function validateStepUsesFormat(diagnostics: Diagnostic[], token: StringT
     return;
   }
 
-  // Local action path - always valid format
-  if (uses.startsWith("./") || uses.startsWith(".\\")) {
-    return;
-  }
-
-  // Self repository reference ($/path): an action resolved from the same repository as the
-  // currently-executing workflow/action. A trailing @ref is not allowed; the ref is
-  // implicitly the same as the executing workflow/action.
-  if (uses.startsWith("$/")) {
-    validateSelfRepositoryUsesFormat(diagnostics, token, uses);
+  // Local and self repository action paths - always valid format
+  if (uses.startsWith("./") || uses.startsWith(".\\") || uses.startsWith("$/")) {
     return;
   }
 
@@ -124,49 +116,4 @@ function addStepUsesFormatError(diagnostics: Diagnostic[], token: StringToken): 
     range: mapRange(token.range),
     code: "invalid-uses-format"
   });
-}
-
-/**
- * Validates the format of a self repository (`$/path`) step `uses` value.
- *
- * Self repository references resolve an action from the same repository as the executing
- * workflow/action. The path after `$/` must be non-empty and must NOT include a version
- * (`@ref`), since the ref is implicitly the same as the executing workflow/action.
- */
-function validateSelfRepositoryUsesFormat(diagnostics: Diagnostic[], token: StringToken, uses: string): void {
-  const path = uses.substring("$/".length);
-
-  // Must reference a non-empty path within the repository
-  if (!path) {
-    diagnostics.push({
-      message: `Expected format $/{path}. Actual '${uses}'`,
-      severity: DiagnosticSeverity.Error,
-      range: mapRange(token.range),
-      code: "invalid-uses-format"
-    });
-    return;
-  }
-
-  // A version (@ref) cannot be specified for self repository references
-  if (uses.includes("@")) {
-    diagnostics.push({
-      message: `A version cannot be specified for self repository references. Expected format $/{path}. Actual '${uses}'`,
-      severity: DiagnosticSeverity.Error,
-      range: mapRange(token.range),
-      code: "invalid-uses-format"
-    });
-    return;
-  }
-
-  // Reusable workflows must be referenced at the job level, not within steps
-  const pathSegments = path.split(/[\\/]/);
-  if (pathSegments.length >= 3 && pathSegments[0] === ".github" && pathSegments[1] === "workflows") {
-    diagnostics.push({
-      message: "Reusable workflows should be referenced at the top-level `jobs.<job_id>.uses` key, not within steps",
-      severity: DiagnosticSeverity.Error,
-      range: mapRange(token.range),
-      code: "invalid-uses-format"
-    });
-    return;
-  }
 }

--- a/languageservice/src/utils/validate-uses.ts
+++ b/languageservice/src/utils/validate-uses.ts
@@ -39,6 +39,7 @@ export function warnIfShortSha(diagnostics: Diagnostic[], token: StringToken, re
  * - docker://image:tag
  * - ./local/path
  * - .\local\path (Windows)
+ * - $/path (self-reference: an action in the same repository as the executing workflow/action)
  * - {owner}/{repo}@{ref}
  * - {owner}/{repo}/{path}@{ref}
  */
@@ -63,6 +64,14 @@ export function validateStepUsesFormat(diagnostics: Diagnostic[], token: StringT
 
   // Local action path - always valid format
   if (uses.startsWith("./") || uses.startsWith(".\\")) {
+    return;
+  }
+
+  // Self-reference ($/path): an action resolved from the same repository as the
+  // currently-executing workflow/action. No version (@ref) is allowed since the ref is
+  // implicitly the same as the executing workflow/action.
+  if (uses.startsWith("$/")) {
+    validateSelfUsesFormat(diagnostics, token, uses);
     return;
   }
 
@@ -115,4 +124,49 @@ function addStepUsesFormatError(diagnostics: Diagnostic[], token: StringToken): 
     range: mapRange(token.range),
     code: "invalid-uses-format"
   });
+}
+
+/**
+ * Validates the format of a self-reference (`$/path`) step `uses` value.
+ *
+ * Self-references resolve an action from the same repository as the executing
+ * workflow/action. The path after `$/` must be non-empty and must not include a version
+ * (`@ref`), since the ref is implicitly the same as the executing workflow/action.
+ */
+function validateSelfUsesFormat(diagnostics: Diagnostic[], token: StringToken, uses: string): void {
+  const path = uses.substring("$/".length);
+
+  // Must reference a non-empty path within the repository
+  if (!path) {
+    diagnostics.push({
+      message: `Expected format $/{path}. Actual '${uses}'`,
+      severity: DiagnosticSeverity.Error,
+      range: mapRange(token.range),
+      code: "invalid-uses-format"
+    });
+    return;
+  }
+
+  // A version cannot be specified for self-references
+  if (uses.includes("@")) {
+    diagnostics.push({
+      message: `A version cannot be specified for self-references. Expected format $/{path}. Actual '${uses}'`,
+      severity: DiagnosticSeverity.Error,
+      range: mapRange(token.range),
+      code: "invalid-uses-format"
+    });
+    return;
+  }
+
+  // Reusable workflows must be referenced at the job level, not within steps
+  const pathSegments = path.split(/[\\/]/);
+  if (pathSegments.length >= 3 && pathSegments[0] === ".github" && pathSegments[1] === "workflows") {
+    diagnostics.push({
+      message: "Reusable workflows should be referenced at the top-level `jobs.<job_id>.uses` key, not within steps",
+      severity: DiagnosticSeverity.Error,
+      range: mapRange(token.range),
+      code: "invalid-uses-format"
+    });
+    return;
+  }
 }

--- a/languageservice/src/utils/validate-uses.ts
+++ b/languageservice/src/utils/validate-uses.ts
@@ -130,16 +130,17 @@ function addStepUsesFormatError(diagnostics: Diagnostic[], token: StringToken): 
  * Validates the format of a self-reference (`$/path`) step `uses` value.
  *
  * Self-references resolve an action from the same repository as the executing
- * workflow/action. The path after `$/` must be non-empty and must not include a version
- * (`@ref`), since the ref is implicitly the same as the executing workflow/action.
+ * workflow/action. The path after `$/` must be non-empty. An optional `@ref` is allowed; if
+ * present, the ref must be non-empty.
  */
 function validateSelfUsesFormat(diagnostics: Diagnostic[], token: StringToken, uses: string): void {
-  const path = uses.substring("$/".length);
+  const withoutPrefix = uses.substring("$/".length);
+  const atSegments = withoutPrefix.split("@");
 
-  // Must reference a non-empty path within the repository
-  if (!path) {
+  // At most one @ separating the path from an optional ref
+  if (atSegments.length > 2) {
     diagnostics.push({
-      message: `Expected format $/{path}. Actual '${uses}'`,
+      message: `Expected format $/{path}[@{ref}]. Actual '${uses}'`,
       severity: DiagnosticSeverity.Error,
       range: mapRange(token.range),
       code: "invalid-uses-format"
@@ -147,10 +148,23 @@ function validateSelfUsesFormat(diagnostics: Diagnostic[], token: StringToken, u
     return;
   }
 
-  // A version cannot be specified for self-references
-  if (uses.includes("@")) {
+  const path = atSegments[0];
+
+  // Must reference a non-empty path within the repository
+  if (!path) {
     diagnostics.push({
-      message: `A version cannot be specified for self-references. Expected format $/{path}. Actual '${uses}'`,
+      message: `Expected format $/{path}[@{ref}]. Actual '${uses}'`,
+      severity: DiagnosticSeverity.Error,
+      range: mapRange(token.range),
+      code: "invalid-uses-format"
+    });
+    return;
+  }
+
+  // If a ref is specified (@...), it cannot be empty
+  if (atSegments.length === 2 && !atSegments[1]) {
+    diagnostics.push({
+      message: `Expected format $/{path}[@{ref}]. Actual '${uses}'`,
       severity: DiagnosticSeverity.Error,
       range: mapRange(token.range),
       code: "invalid-uses-format"

--- a/languageservice/src/utils/validate-uses.ts
+++ b/languageservice/src/utils/validate-uses.ts
@@ -39,7 +39,7 @@ export function warnIfShortSha(diagnostics: Diagnostic[], token: StringToken, re
  * - docker://image:tag
  * - ./local/path
  * - .\local\path (Windows)
- * - $/path (self-reference: an action in the same repository as the executing workflow/action)
+ * - $/path (self repository reference: an action in the same repository as the executing workflow/action)
  * - {owner}/{repo}@{ref}
  * - {owner}/{repo}/{path}@{ref}
  */
@@ -67,11 +67,11 @@ export function validateStepUsesFormat(diagnostics: Diagnostic[], token: StringT
     return;
   }
 
-  // Self-reference ($/path): an action resolved from the same repository as the
+  // Self repository reference ($/path): an action resolved from the same repository as the
   // currently-executing workflow/action. A trailing @ref is not allowed; the ref is
   // implicitly the same as the executing workflow/action.
   if (uses.startsWith("$/")) {
-    validateSelfUsesFormat(diagnostics, token, uses);
+    validateSelfRepositoryUsesFormat(diagnostics, token, uses);
     return;
   }
 
@@ -127,13 +127,13 @@ function addStepUsesFormatError(diagnostics: Diagnostic[], token: StringToken): 
 }
 
 /**
- * Validates the format of a self-reference (`$/path`) step `uses` value.
+ * Validates the format of a self repository (`$/path`) step `uses` value.
  *
- * Self-references resolve an action from the same repository as the executing
+ * Self repository references resolve an action from the same repository as the executing
  * workflow/action. The path after `$/` must be non-empty and must NOT include a version
  * (`@ref`), since the ref is implicitly the same as the executing workflow/action.
  */
-function validateSelfUsesFormat(diagnostics: Diagnostic[], token: StringToken, uses: string): void {
+function validateSelfRepositoryUsesFormat(diagnostics: Diagnostic[], token: StringToken, uses: string): void {
   const path = uses.substring("$/".length);
 
   // Must reference a non-empty path within the repository
@@ -147,10 +147,10 @@ function validateSelfUsesFormat(diagnostics: Diagnostic[], token: StringToken, u
     return;
   }
 
-  // A version (@ref) cannot be specified for self-references
+  // A version (@ref) cannot be specified for self repository references
   if (uses.includes("@")) {
     diagnostics.push({
-      message: `A version cannot be specified for self-references. Expected format $/{path}. Actual '${uses}'`,
+      message: `A version cannot be specified for self repository references. Expected format $/{path}. Actual '${uses}'`,
       severity: DiagnosticSeverity.Error,
       range: mapRange(token.range),
       code: "invalid-uses-format"

--- a/languageservice/src/utils/validate-uses.ts
+++ b/languageservice/src/utils/validate-uses.ts
@@ -68,8 +68,8 @@ export function validateStepUsesFormat(diagnostics: Diagnostic[], token: StringT
   }
 
   // Self-reference ($/path): an action resolved from the same repository as the
-  // currently-executing workflow/action. A trailing @ref is accepted (and ignored), matching
-  // the runtime parser and the rest of the tooling fleet.
+  // currently-executing workflow/action. A trailing @ref is not allowed; the ref is
+  // implicitly the same as the executing workflow/action.
   if (uses.startsWith("$/")) {
     validateSelfUsesFormat(diagnostics, token, uses);
     return;
@@ -130,30 +130,16 @@ function addStepUsesFormatError(diagnostics: Diagnostic[], token: StringToken): 
  * Validates the format of a self-reference (`$/path`) step `uses` value.
  *
  * Self-references resolve an action from the same repository as the executing
- * workflow/action. The path after `$/` must be non-empty. An optional `@ref` is allowed; if
- * present, the ref must be non-empty.
+ * workflow/action. The path after `$/` must be non-empty and must NOT include a version
+ * (`@ref`), since the ref is implicitly the same as the executing workflow/action.
  */
 function validateSelfUsesFormat(diagnostics: Diagnostic[], token: StringToken, uses: string): void {
-  const withoutPrefix = uses.substring("$/".length);
-  const atSegments = withoutPrefix.split("@");
-
-  // At most one @ separating the path from an optional ref
-  if (atSegments.length > 2) {
-    diagnostics.push({
-      message: `Expected format $/{path}[@{ref}]. Actual '${uses}'`,
-      severity: DiagnosticSeverity.Error,
-      range: mapRange(token.range),
-      code: "invalid-uses-format"
-    });
-    return;
-  }
-
-  const path = atSegments[0];
+  const path = uses.substring("$/".length);
 
   // Must reference a non-empty path within the repository
   if (!path) {
     diagnostics.push({
-      message: `Expected format $/{path}[@{ref}]. Actual '${uses}'`,
+      message: `Expected format $/{path}. Actual '${uses}'`,
       severity: DiagnosticSeverity.Error,
       range: mapRange(token.range),
       code: "invalid-uses-format"
@@ -161,10 +147,10 @@ function validateSelfUsesFormat(diagnostics: Diagnostic[], token: StringToken, u
     return;
   }
 
-  // If a ref is specified (@...), it cannot be empty
-  if (atSegments.length === 2 && !atSegments[1]) {
+  // A version (@ref) cannot be specified for self-references
+  if (uses.includes("@")) {
     diagnostics.push({
-      message: `Expected format $/{path}[@{ref}]. Actual '${uses}'`,
+      message: `A version cannot be specified for self-references. Expected format $/{path}. Actual '${uses}'`,
       severity: DiagnosticSeverity.Error,
       range: mapRange(token.range),
       code: "invalid-uses-format"

--- a/languageservice/src/validate-action-reference.ts
+++ b/languageservice/src/validate-action-reference.ts
@@ -36,10 +36,10 @@ export async function validateActionReference(
 
   const uses = step.uses.value;
 
-  // Self-reference ($/path): resolve the action from the same repository as the executing
+  // Self repository reference ($/path): resolve the action from the same repository as the executing
   // workflow/action. The target directory must contain an `action.yml` or `action.yaml`.
   if (uses.startsWith("$/")) {
-    await validateSelfActionReference(diagnostics, step.uses.value, step.uses.range, config);
+    await validateSelfRepositoryActionReference(diagnostics, step.uses.value, step.uses.range, config);
     return;
   }
 
@@ -141,16 +141,16 @@ export async function validateActionReference(
 }
 
 /**
- * Validates a self-reference (`$/path`) action `uses` value by resolving the referenced
+ * Validates a self repository (`$/path`) action `uses` value by resolving the referenced
  * action within the same repository. The target directory must contain an `action.yml` or
  * `action.yaml` manifest.
  *
  * The existence check requires a `FileProvider` (the same mechanism used to resolve reusable
  * workflows). When no `FileProvider` is configured, the check is skipped so we don't emit a
  * false error. Format-level problems (empty path, `@ref`) are reported by
- * `validateStepUsesFormat`, so this only runs for well-formed self-references.
+ * `validateStepUsesFormat`, so this only runs for well-formed self repository references.
  */
-async function validateSelfActionReference(
+async function validateSelfRepositoryActionReference(
   diagnostics: Diagnostic[],
   uses: string,
   range: TokenRange | undefined,
@@ -163,7 +163,7 @@ async function validateSelfActionReference(
 
   const path = uses.substring("$/".length);
 
-  // Skip malformed self-references (empty path or a trailing @ref); those are reported by
+  // Skip malformed self repository references (empty path or a trailing @ref); those are reported by
   // validateStepUsesFormat.
   if (!path || uses.includes("@")) {
     return;

--- a/languageservice/src/validate-action-reference.ts
+++ b/languageservice/src/validate-action-reference.ts
@@ -161,10 +161,11 @@ async function validateSelfActionReference(
     return;
   }
 
-  const path = uses.substring("$/".length).split("@")[0];
+  const path = uses.substring("$/".length);
 
-  // Skip malformed self-references; those are reported by validateStepUsesFormat.
-  if (!path) {
+  // Skip malformed self-references (empty path or a trailing @ref); those are reported by
+  // validateStepUsesFormat.
+  if (!path || uses.includes("@")) {
     return;
   }
 

--- a/languageservice/src/validate-action-reference.ts
+++ b/languageservice/src/validate-action-reference.ts
@@ -1,11 +1,13 @@
 import {isMapping} from "@actions/workflow-parser";
 import {isActionStep} from "@actions/workflow-parser/model/type-guards";
 import {Step} from "@actions/workflow-parser/model/workflow-template";
+import {MappingToken} from "@actions/workflow-parser/templates/tokens/mapping-token";
 import {ScalarToken} from "@actions/workflow-parser/templates/tokens/scalar-token";
 import {TemplateToken} from "@actions/workflow-parser/templates/tokens/template-token";
 import {TokenRange} from "@actions/workflow-parser/templates/tokens/token-range";
 import {Diagnostic, DiagnosticSeverity} from "vscode-languageserver-types";
-import {ActionReference, parseActionReference} from "./action.js";
+import {parse} from "yaml";
+import {ActionMetadata, ActionReference, parseActionReference} from "./action.js";
 import {mapRange} from "./utils/range.js";
 import {ValidationConfig} from "./validate.js";
 
@@ -14,7 +16,7 @@ export const DiagnosticCode = {
 } as const;
 
 export interface MissingInputsDiagnosticData {
-  action: ActionReference;
+  action?: ActionReference;
   missingInputs: Array<{
     name: string;
     default?: string;
@@ -35,35 +37,47 @@ export async function validateActionReference(
   }
 
   const uses = step.uses.value;
+  let action: ActionReference | undefined;
+  let actionMetadata: ActionMetadata | undefined;
 
-  // Self repository reference ($/path): resolve the action from the same repository as the executing
-  // workflow/action. The target directory must contain an `action.yml` or `action.yaml`.
   if (uses.startsWith("$/")) {
-    await validateSelfRepositoryActionReference(diagnostics, step.uses.value, step.uses.range, config);
-    return;
+    actionMetadata = await fetchSelfRepositoryActionMetadata(diagnostics, uses, step.uses.range, config);
+  } else {
+    if (!config?.actionsMetadataProvider) {
+      return;
+    }
+
+    // Parse the action reference (e.g., "actions/checkout@v4" -> {owner, name, ref})
+    action = parseActionReference(uses);
+    if (!action) {
+      return;
+    }
+
+    // Fetch the action's metadata (action.yml) to get input definitions
+    actionMetadata = await config.actionsMetadataProvider.fetchActionMetadata(action);
+    if (actionMetadata === undefined) {
+      diagnostics.push({
+        severity: DiagnosticSeverity.Error,
+        range: mapRange(step.uses.range),
+        message: `Unable to resolve action \`${uses}\`, repository or version not found`
+      });
+      return;
+    }
   }
 
-  if (!config?.actionsMetadataProvider) {
-    return;
-  }
-
-  // Parse the action reference (e.g., "actions/checkout@v4" -> {owner, name, ref})
-  const action = parseActionReference(step.uses.value);
-  if (!action) {
-    return;
-  }
-
-  // Fetch the action's metadata (action.yml) to get input definitions
-  const actionMetadata = await config.actionsMetadataProvider.fetchActionMetadata(action);
   if (actionMetadata === undefined) {
-    diagnostics.push({
-      severity: DiagnosticSeverity.Error,
-      range: mapRange(step.uses.range),
-      message: `Unable to resolve action \`${step.uses.value}\`, repository or version not found`
-    });
     return;
   }
 
+  validateActionInputs(diagnostics, stepToken, actionMetadata, action);
+}
+
+function validateActionInputs(
+  diagnostics: Diagnostic[],
+  stepToken: MappingToken,
+  actionMetadata: ActionMetadata,
+  action: ActionReference | undefined
+): void {
   // Find the "with" key in the step token to get the inputs passed to the action
   let withKey: ScalarToken | undefined;
   let withToken: TemplateToken | undefined;
@@ -123,7 +137,7 @@ export async function validateActionReference(
 
     // Build minimal diagnostic data - position calculation happens in the quickfix
     const diagnosticData: MissingInputsDiagnosticData = {
-      action,
+      ...(action ? {action} : {}),
       missingInputs: missingRequiredInputs.map(([name, input]) => ({
         name,
         default: input.default
@@ -141,21 +155,18 @@ export async function validateActionReference(
 }
 
 /**
- * Validates a self repository (`$/path`) action `uses` value by resolving the referenced
- * action within the same repository. The target directory must contain an `action.yml` or
- * `action.yaml` manifest.
+ * Fetches metadata for a self repository (`$/path`) action from the same repository.
  *
- * The existence check requires a `FileProvider` (the same mechanism used to resolve reusable
- * workflows). When no `FileProvider` is configured, the check is skipped so we don't emit a
- * false error. Format-level problems (empty path, `@ref`) are reported by
- * `validateStepUsesFormat`, so this only runs for well-formed self repository references.
+ * Resolution requires a `FileProvider`, the same mechanism used for reusable workflows. When
+ * none is configured, validation is skipped to avoid a false error. Format-level problems are
+ * reported by `validateStepUsesFormat`.
  */
-async function validateSelfRepositoryActionReference(
+async function fetchSelfRepositoryActionMetadata(
   diagnostics: Diagnostic[],
   uses: string,
   range: TokenRange | undefined,
   config: ValidationConfig | undefined
-): Promise<void> {
+): Promise<ActionMetadata | undefined> {
   const fileProvider = config?.fileProvider;
   if (!fileProvider) {
     return;
@@ -169,13 +180,19 @@ async function validateSelfRepositoryActionReference(
     return;
   }
 
+  let content: string | undefined;
   for (const manifest of ["action.yml", "action.yaml"]) {
     try {
-      await fileProvider.getFileContent({path: `${path}/${manifest}`});
-      return; // Found a valid action manifest
+      const file = await fileProvider.getFileContent({path: `${path}/${manifest}`});
+      content = file.content;
+      break;
     } catch {
       // Try the next manifest filename
     }
+  }
+
+  if (content !== undefined) {
+    return parse(content) as ActionMetadata;
   }
 
   diagnostics.push({

--- a/languageservice/src/validate-action-reference.ts
+++ b/languageservice/src/validate-action-reference.ts
@@ -3,6 +3,7 @@ import {isActionStep} from "@actions/workflow-parser/model/type-guards";
 import {Step} from "@actions/workflow-parser/model/workflow-template";
 import {ScalarToken} from "@actions/workflow-parser/templates/tokens/scalar-token";
 import {TemplateToken} from "@actions/workflow-parser/templates/tokens/template-token";
+import {TokenRange} from "@actions/workflow-parser/templates/tokens/token-range";
 import {Diagnostic, DiagnosticSeverity} from "vscode-languageserver-types";
 import {ActionReference, parseActionReference} from "./action.js";
 import {mapRange} from "./utils/range.js";
@@ -29,7 +30,20 @@ export async function validateActionReference(
   step: Step | undefined,
   config: ValidationConfig | undefined
 ): Promise<void> {
-  if (!isMapping(stepToken) || !step || !isActionStep(step) || !config?.actionsMetadataProvider) {
+  if (!isMapping(stepToken) || !step || !isActionStep(step)) {
+    return;
+  }
+
+  const uses = step.uses.value;
+
+  // Self-reference ($/path): resolve the action from the same repository as the executing
+  // workflow/action. The target directory must contain an `action.yml` or `action.yaml`.
+  if (uses.startsWith("$/")) {
+    await validateSelfActionReference(diagnostics, step.uses.value, step.uses.range, config);
+    return;
+  }
+
+  if (!config?.actionsMetadataProvider) {
     return;
   }
 
@@ -124,4 +138,49 @@ export async function validateActionReference(
       data: diagnosticData
     });
   }
+}
+
+/**
+ * Validates a self-reference (`$/path`) action `uses` value by resolving the referenced
+ * action within the same repository. The target directory must contain an `action.yml` or
+ * `action.yaml` manifest.
+ *
+ * The existence check requires a `FileProvider` (the same mechanism used to resolve reusable
+ * workflows). When no `FileProvider` is configured, the check is skipped so we don't emit a
+ * false error. Format-level problems (empty path, `@ref`) are reported by
+ * `validateStepUsesFormat`, so this only runs for well-formed self-references.
+ */
+async function validateSelfActionReference(
+  diagnostics: Diagnostic[],
+  uses: string,
+  range: TokenRange | undefined,
+  config: ValidationConfig | undefined
+): Promise<void> {
+  const fileProvider = config?.fileProvider;
+  if (!fileProvider) {
+    return;
+  }
+
+  const path = uses.substring("$/".length);
+
+  // Skip malformed self-references; those are reported by validateStepUsesFormat.
+  if (!path || uses.includes("@")) {
+    return;
+  }
+
+  for (const manifest of ["action.yml", "action.yaml"]) {
+    try {
+      await fileProvider.getFileContent({path: `${path}/${manifest}`});
+      return; // Found a valid action manifest
+    } catch {
+      // Try the next manifest filename
+    }
+  }
+
+  diagnostics.push({
+    severity: DiagnosticSeverity.Error,
+    range: mapRange(range),
+    message: `Unable to resolve action \`${uses}\`, no 'action.yml' or 'action.yaml' found in '${path}'`,
+    code: "invalid-uses-format"
+  });
 }

--- a/languageservice/src/validate-action-reference.ts
+++ b/languageservice/src/validate-action-reference.ts
@@ -161,10 +161,10 @@ async function validateSelfActionReference(
     return;
   }
 
-  const path = uses.substring("$/".length);
+  const path = uses.substring("$/".length).split("@")[0];
 
   // Skip malformed self-references; those are reported by validateStepUsesFormat.
-  if (!path || uses.includes("@")) {
+  if (!path) {
     return;
   }
 

--- a/languageservice/src/validate-action.test.ts
+++ b/languageservice/src/validate-action.test.ts
@@ -26,7 +26,7 @@ runs:
       expect(diagnostics).toEqual([]);
     });
 
-    it("validates a composite action with a $/ self-reference step", async () => {
+    it("validates a composite action with a $/ self repository step", async () => {
       const doc = createActionDocument(`
 name: My Action
 description: Does something

--- a/languageservice/src/validate-action.test.ts
+++ b/languageservice/src/validate-action.test.ts
@@ -26,6 +26,19 @@ runs:
       expect(diagnostics).toEqual([]);
     });
 
+    it("validates a composite action with a $/ self-reference step", async () => {
+      const doc = createActionDocument(`
+name: My Action
+description: Does something
+runs:
+  using: composite
+  steps:
+    - uses: $/actions/nested
+`);
+      const diagnostics = await validate(doc);
+      expect(diagnostics).toEqual([]);
+    });
+
     it("validates a node20 action", async () => {
       const doc = createActionDocument(`
 name: My Action

--- a/languageservice/src/validate.self-repository-uses.test.ts
+++ b/languageservice/src/validate.self-repository-uses.test.ts
@@ -32,8 +32,8 @@ runs:
   }
 };
 
-describe("self-reference ($/) action resolution", () => {
-  it("valid self-reference resolves to an action.yml", async () => {
+describe("self repository ($/) action resolution", () => {
+  it("valid self repository reference resolves to an action.yml", async () => {
     const input = `on: push
 jobs:
   build:
@@ -47,7 +47,7 @@ jobs:
     expect(result).toEqual([]);
   });
 
-  it("self-reference to a directory without an action manifest reports an error", async () => {
+  it("self repository reference to a directory without an action manifest reports an error", async () => {
     const input = `on: push
 jobs:
   build:

--- a/languageservice/src/validate.self-repository-uses.test.ts
+++ b/languageservice/src/validate.self-repository-uses.test.ts
@@ -9,8 +9,7 @@ beforeEach(() => {
   clearCache();
 });
 
-// Resolves self repository actions ($/path) against a fake in-repo file system. Only
-// `actions/my-action/action.yml` exists.
+// Resolves self repository actions ($/path) against a fake in-repo file system.
 const selfActionFileProvider: FileProvider = {
   // eslint-disable-next-line @typescript-eslint/require-await
   getFileContent: async ref => {
@@ -20,6 +19,23 @@ const selfActionFileProvider: FileProvider = {
           name: "actions/my-action/action.yml",
           content: `name: My Action
 description: A self repository action
+runs:
+  using: node20
+  main: index.js
+`
+        };
+
+      case "./actions/action-with-inputs/action.yml":
+        return {
+          name: "actions/action-with-inputs/action.yml",
+          content: `name: Action with inputs
+description: A self repository action with inputs
+inputs:
+  required-input:
+    description: A required input
+    required: true
+  optional-input:
+    description: An optional input
 runs:
   using: node20
   main: index.js
@@ -45,6 +61,51 @@ jobs:
       fileProvider: selfActionFileProvider
     });
     expect(result).toEqual([]);
+  });
+
+  it("validates inputs from the self repository action metadata", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/action-with-inputs
+      with:
+        unknown-input: value
+        required-input: value
+`;
+    const result = await validate(createDocument("wf.yaml", input), {
+      fileProvider: selfActionFileProvider
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      severity: DiagnosticSeverity.Error,
+      message: "Invalid action input 'unknown-input'"
+    });
+  });
+
+  it("reports required inputs from the self repository action metadata", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/action-with-inputs
+`;
+    const result = await validate(createDocument("wf.yaml", input), {
+      fileProvider: selfActionFileProvider
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      severity: DiagnosticSeverity.Error,
+      message: "Missing required input `required-input`",
+      code: "missing-required-inputs",
+      data: {
+        missingInputs: [{name: "required-input"}]
+      }
+    });
   });
 
   it("self repository reference to a directory without an action manifest reports an error", async () => {

--- a/languageservice/src/validate.self-repository-uses.test.ts
+++ b/languageservice/src/validate.self-repository-uses.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
   clearCache();
 });
 
-// Resolves self-referenced actions ($/path) against a fake in-repo file system. Only
+// Resolves self repository actions ($/path) against a fake in-repo file system. Only
 // `actions/my-action/action.yml` exists.
 const selfActionFileProvider: FileProvider = {
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -19,7 +19,7 @@ const selfActionFileProvider: FileProvider = {
         return {
           name: "actions/my-action/action.yml",
           content: `name: My Action
-description: A self-referenced action
+description: A self repository action
 runs:
   using: node20
   main: index.js

--- a/languageservice/src/validate.self-uses.test.ts
+++ b/languageservice/src/validate.self-uses.test.ts
@@ -1,0 +1,86 @@
+import {FileProvider} from "@actions/workflow-parser/workflows/file-provider";
+import {fileIdentifier} from "@actions/workflow-parser/workflows/file-reference";
+import {DiagnosticSeverity} from "vscode-languageserver-types";
+import {createDocument} from "./test-utils/document.js";
+import {clearCache} from "./utils/workflow-cache.js";
+import {validate} from "./validate.js";
+
+beforeEach(() => {
+  clearCache();
+});
+
+// Resolves self-referenced actions ($/path) against a fake in-repo file system. Only
+// `actions/my-action/action.yml` exists.
+const selfActionFileProvider: FileProvider = {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  getFileContent: async ref => {
+    switch (fileIdentifier(ref)) {
+      case "./actions/my-action/action.yml":
+        return {
+          name: "actions/my-action/action.yml",
+          content: `name: My Action
+description: A self-referenced action
+runs:
+  using: node20
+  main: index.js
+`
+        };
+
+      default:
+        throw new Error("File not found");
+    }
+  }
+};
+
+describe("self-reference ($/) action resolution", () => {
+  it("valid self-reference resolves to an action.yml", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/my-action
+`;
+    const result = await validate(createDocument("wf.yaml", input), {
+      fileProvider: selfActionFileProvider
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("self-reference to a directory without an action manifest reports an error", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/missing
+`;
+    const result = await validate(createDocument("wf.yaml", input), {
+      fileProvider: selfActionFileProvider
+    });
+    expect(result).toEqual([
+      {
+        severity: DiagnosticSeverity.Error,
+        range: {
+          start: {line: 5, character: 12},
+          end: {line: 5, character: 29}
+        },
+        message:
+          "Unable to resolve action `$/actions/missing`, no 'action.yml' or 'action.yaml' found in 'actions/missing'",
+        code: "invalid-uses-format"
+      }
+    ]);
+  });
+
+  it("skips the existence check when no fileProvider is configured", async () => {
+    const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/missing
+`;
+    const result = await validate(createDocument("wf.yaml", input));
+    expect(result).toEqual([]);
+  });
+});

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -320,18 +320,18 @@ function validateCronExpression(diagnostics: Diagnostic[], token: StringToken): 
 function validateWorkflowUsesFormat(diagnostics: Diagnostic[], token: StringToken): void {
   const uses = token.value;
 
-  // Self workflow reference: `$/` resolves within the same repository at the running
+  // Self repository workflow reference: `$/` resolves within the same repository at the running
   // SHA, exactly like `./` for local reusable workflows.
   if (uses.startsWith("$/")) {
-    // Cannot have @ version for self-references
+    // Cannot have @ version for self repository references
     if (uses.includes("@")) {
-      addWorkflowUsesFormatError(diagnostics, token, "cannot specify version when calling self-referenced workflows");
+      addWorkflowUsesFormatError(diagnostics, token, "cannot specify version when calling self repository workflows");
       return;
     }
 
     const selfPath = uses.substring(2);
     if (!selfPath.startsWith(".github/workflows/") && !selfPath.startsWith(".github/workflows-lab/")) {
-      addWorkflowUsesFormatError(diagnostics, token, "self-referenced workflows must be rooted in '.github/workflows'");
+      addWorkflowUsesFormatError(diagnostics, token, "self repository workflows must be rooted in '.github/workflows'");
       return;
     }
 

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -320,18 +320,21 @@ function validateCronExpression(diagnostics: Diagnostic[], token: StringToken): 
 function validateWorkflowUsesFormat(diagnostics: Diagnostic[], token: StringToken): void {
   const uses = token.value;
 
-  // Self repository workflow reference: `$/` resolves within the same repository at the running
-  // SHA, exactly like `./` for local reusable workflows.
-  if (uses.startsWith("$/")) {
-    // Cannot have @ version for self repository references
-    if (uses.includes("@")) {
-      addWorkflowUsesFormatError(diagnostics, token, "cannot specify version when calling self repository workflows");
-      return;
-    }
+  const isLocalWorkflow = uses.startsWith("./.github/workflows/") || uses.startsWith("./.github/workflows-lab/");
+  const isSelfRepositoryWorkflow =
+    uses.startsWith("$/.github/workflows/") || uses.startsWith("$/.github/workflows-lab/");
 
-    const selfPath = uses.substring(2);
-    if (!selfPath.startsWith(".github/workflows/") && !selfPath.startsWith(".github/workflows-lab/")) {
-      addWorkflowUsesFormatError(diagnostics, token, "self repository workflows must be rooted in '.github/workflows'");
+  // Local or self repository workflow reference
+  if (isLocalWorkflow || isSelfRepositoryWorkflow) {
+    // Cannot have @ version for local or self repository workflows
+    if (uses.includes("@")) {
+      addWorkflowUsesFormatError(
+        diagnostics,
+        token,
+        isSelfRepositoryWorkflow
+          ? "cannot specify version when calling self repository workflows"
+          : "cannot specify version when calling local workflows"
+      );
       return;
     }
 
@@ -348,7 +351,6 @@ function validateWorkflowUsesFormat(diagnostics: Diagnostic[], token: StringToke
     // Must be at top level of .github/workflows/ or .github/workflows-lab/ (no subdirectories)
     const pathParts = uses.split("/");
     if (pathParts.length !== 4) {
-      // Expected: "$", ".github", "workflows" or "workflows-lab", "filename.yml"
       addWorkflowUsesFormatError(
         diagnostics,
         token,
@@ -367,49 +369,15 @@ function validateWorkflowUsesFormat(diagnostics: Diagnostic[], token: StringToke
     return;
   }
 
-  // Local workflow reference
-  if (uses.startsWith("./.github/workflows/") || uses.startsWith("./.github/workflows-lab/")) {
-    // Cannot have @ version for local workflows
-    if (uses.includes("@")) {
-      addWorkflowUsesFormatError(diagnostics, token, "cannot specify version when calling local workflows");
-      return;
-    }
-
-    // Must have .yml or .yaml extension
-    if (!uses.endsWith(".yml") && !uses.endsWith(".yaml")) {
-      addWorkflowUsesFormatError(
-        diagnostics,
-        token,
-        "workflow file should have either a '.yml' or '.yaml' file extension"
-      );
-      return;
-    }
-
-    // Must be at top level of .github/workflows/ or .github/workflows-lab/ (no subdirectories)
-    const pathParts = uses.split("/");
-    if (pathParts.length !== 4) {
-      // Expected: ".", ".github", "workflows" or "workflows-lab", "filename.yml"
-      addWorkflowUsesFormatError(
-        diagnostics,
-        token,
-        "workflows must be defined at the top level of the .github/workflows/ directory"
-      );
-      return;
-    }
-
-    // Filename cannot be just the extension
-    const filename = pathParts[3];
-    if (filename === ".yml" || filename === ".yaml") {
-      addWorkflowUsesFormatError(diagnostics, token, "invalid workflow file name");
-      return;
-    }
-
-    return;
-  }
-
-  // Malformed local workflow reference (starts with ./ but not in .github/workflows)
-  if (uses.startsWith("./")) {
-    addWorkflowUsesFormatError(diagnostics, token, "local workflow references must be rooted in '.github/workflows'");
+  // Malformed local or self repository workflow reference
+  if (uses.startsWith("./") || uses.startsWith("$/")) {
+    addWorkflowUsesFormatError(
+      diagnostics,
+      token,
+      uses.startsWith("$/")
+        ? "self repository workflows must be rooted in '.github/workflows'"
+        : "local workflow references must be rooted in '.github/workflows'"
+    );
     return;
   }
 

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -316,56 +316,6 @@ function validateCronExpression(diagnostics: Diagnostic[], token: StringToken): 
 function validateWorkflowUsesFormat(diagnostics: Diagnostic[], token: StringToken): void {
   const uses = token.value;
 
-  // Self-reference ($/path): a reusable workflow resolved from the same repository as the
-  // executing workflow. Must be rooted in .github/workflows(-lab)/, at the top level, with a
-  // .yml/.yaml extension, and cannot specify a version (@ref).
-  if (uses.startsWith("$/")) {
-    // Cannot have @ version for self-references
-    if (uses.includes("@")) {
-      addWorkflowUsesFormatError(diagnostics, token, "cannot specify version when calling self-referenced workflows");
-      return;
-    }
-
-    const path = uses.substring("$/".length);
-
-    // Must be rooted in .github/workflows/ or .github/workflows-lab/
-    if (!path.startsWith(".github/workflows/") && !path.startsWith(".github/workflows-lab/")) {
-      addWorkflowUsesFormatError(diagnostics, token, "self-referenced workflows must be rooted in '.github/workflows'");
-      return;
-    }
-
-    // Must have .yml or .yaml extension
-    if (!path.endsWith(".yml") && !path.endsWith(".yaml")) {
-      addWorkflowUsesFormatError(
-        diagnostics,
-        token,
-        "workflow file should have either a '.yml' or '.yaml' file extension"
-      );
-      return;
-    }
-
-    // Must be at the top level of .github/workflows(-lab)/ (no subdirectories)
-    const pathParts = path.split("/");
-    if (pathParts.length !== 3) {
-      // Expected: ".github", "workflows" or "workflows-lab", "filename.yml"
-      addWorkflowUsesFormatError(
-        diagnostics,
-        token,
-        "workflows must be defined at the top level of the .github/workflows/ directory"
-      );
-      return;
-    }
-
-    // Filename cannot be just the extension
-    const filename = pathParts[2];
-    if (filename === ".yml" || filename === ".yaml") {
-      addWorkflowUsesFormatError(diagnostics, token, "invalid workflow file name");
-      return;
-    }
-
-    return;
-  }
-
   // Local workflow reference
   if (uses.startsWith("./.github/workflows/") || uses.startsWith("./.github/workflows-lab/")) {
     // Cannot have @ version for local workflows

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -316,6 +316,56 @@ function validateCronExpression(diagnostics: Diagnostic[], token: StringToken): 
 function validateWorkflowUsesFormat(diagnostics: Diagnostic[], token: StringToken): void {
   const uses = token.value;
 
+  // Self-reference ($/path): a reusable workflow resolved from the same repository as the
+  // executing workflow. Must be rooted in .github/workflows(-lab)/, at the top level, with a
+  // .yml/.yaml extension, and cannot specify a version (@ref).
+  if (uses.startsWith("$/")) {
+    // Cannot have @ version for self-references
+    if (uses.includes("@")) {
+      addWorkflowUsesFormatError(diagnostics, token, "cannot specify version when calling self-referenced workflows");
+      return;
+    }
+
+    const path = uses.substring("$/".length);
+
+    // Must be rooted in .github/workflows/ or .github/workflows-lab/
+    if (!path.startsWith(".github/workflows/") && !path.startsWith(".github/workflows-lab/")) {
+      addWorkflowUsesFormatError(diagnostics, token, "self-referenced workflows must be rooted in '.github/workflows'");
+      return;
+    }
+
+    // Must have .yml or .yaml extension
+    if (!path.endsWith(".yml") && !path.endsWith(".yaml")) {
+      addWorkflowUsesFormatError(
+        diagnostics,
+        token,
+        "workflow file should have either a '.yml' or '.yaml' file extension"
+      );
+      return;
+    }
+
+    // Must be at the top level of .github/workflows(-lab)/ (no subdirectories)
+    const pathParts = path.split("/");
+    if (pathParts.length !== 3) {
+      // Expected: ".github", "workflows" or "workflows-lab", "filename.yml"
+      addWorkflowUsesFormatError(
+        diagnostics,
+        token,
+        "workflows must be defined at the top level of the .github/workflows/ directory"
+      );
+      return;
+    }
+
+    // Filename cannot be just the extension
+    const filename = pathParts[2];
+    if (filename === ".yml" || filename === ".yaml") {
+      addWorkflowUsesFormatError(diagnostics, token, "invalid workflow file name");
+      return;
+    }
+
+    return;
+  }
+
   // Local workflow reference
   if (uses.startsWith("./.github/workflows/") || uses.startsWith("./.github/workflows-lab/")) {
     // Cannot have @ version for local workflows

--- a/languageservice/src/validate.ts
+++ b/languageservice/src/validate.ts
@@ -312,9 +312,60 @@ function validateCronExpression(diagnostics: Diagnostic[], token: StringToken): 
  * - ./.github/workflows/{filename}.yaml
  * - ./.github/workflows-lab/{filename}.yml
  * - ./.github/workflows-lab/{filename}.yaml
+ * - $/.github/workflows/{filename}.yml
+ * - $/.github/workflows/{filename}.yaml
+ * - $/.github/workflows-lab/{filename}.yml
+ * - $/.github/workflows-lab/{filename}.yaml
  */
 function validateWorkflowUsesFormat(diagnostics: Diagnostic[], token: StringToken): void {
   const uses = token.value;
+
+  // Self workflow reference: `$/` resolves within the same repository at the running
+  // SHA, exactly like `./` for local reusable workflows.
+  if (uses.startsWith("$/")) {
+    // Cannot have @ version for self-references
+    if (uses.includes("@")) {
+      addWorkflowUsesFormatError(diagnostics, token, "cannot specify version when calling self-referenced workflows");
+      return;
+    }
+
+    const selfPath = uses.substring(2);
+    if (!selfPath.startsWith(".github/workflows/") && !selfPath.startsWith(".github/workflows-lab/")) {
+      addWorkflowUsesFormatError(diagnostics, token, "self-referenced workflows must be rooted in '.github/workflows'");
+      return;
+    }
+
+    // Must have .yml or .yaml extension
+    if (!uses.endsWith(".yml") && !uses.endsWith(".yaml")) {
+      addWorkflowUsesFormatError(
+        diagnostics,
+        token,
+        "workflow file should have either a '.yml' or '.yaml' file extension"
+      );
+      return;
+    }
+
+    // Must be at top level of .github/workflows/ or .github/workflows-lab/ (no subdirectories)
+    const pathParts = uses.split("/");
+    if (pathParts.length !== 4) {
+      // Expected: "$", ".github", "workflows" or "workflows-lab", "filename.yml"
+      addWorkflowUsesFormatError(
+        diagnostics,
+        token,
+        "workflows must be defined at the top level of the .github/workflows/ directory"
+      );
+      return;
+    }
+
+    // Filename cannot be just the extension
+    const filename = pathParts[3];
+    if (filename === ".yml" || filename === ".yaml") {
+      addWorkflowUsesFormatError(diagnostics, token, "invalid workflow file name");
+      return;
+    }
+
+    return;
+  }
 
   // Local workflow reference
   if (uses.startsWith("./.github/workflows/") || uses.startsWith("./.github/workflows-lab/")) {

--- a/languageservice/src/validate.uses-format.test.ts
+++ b/languageservice/src/validate.uses-format.test.ts
@@ -448,6 +448,36 @@ jobs:
       expect(result).toEqual([]);
     });
 
+    it("self-reference workflow path", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/.github/workflows/test.yml
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
+
+    it("self-reference workflow path with yaml extension", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/.github/workflows/test.yaml
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
+
+    it("self-reference workflows-lab path", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/.github/workflows-lab/test.yml
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
+
     it("remote workflow with version", async () => {
       const input = `on: push
 jobs:
@@ -687,20 +717,21 @@ jobs:
       ]);
     });
 
-    it("self-reference workflow is not supported at job level", async () => {
+    it("self-reference workflow with @ref is not supported at job level", async () => {
       const input = `on: push
 jobs:
   test:
-    uses: $/.github/workflows/test.yml
+    uses: $/.github/workflows/test.yml@v1
 `;
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([
         {
-          message: "Invalid workflow reference '$/.github/workflows/test.yml': no version specified",
+          message:
+            "Invalid workflow reference '$/.github/workflows/test.yml@v1': cannot specify version when calling self-referenced workflows",
           severity: DiagnosticSeverity.Error,
           range: {
             start: {line: 3, character: 10},
-            end: {line: 3, character: 38}
+            end: {line: 3, character: 41}
           },
           code: "invalid-workflow-uses-format"
         }

--- a/languageservice/src/validate.uses-format.test.ts
+++ b/languageservice/src/validate.uses-format.test.ts
@@ -128,6 +128,30 @@ jobs:
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([]);
     });
+
+    it("self-reference with $/", async () => {
+      const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/composite
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
+
+    it("self-reference with $/ and subdirectories", async () => {
+      const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/.github/actions/nested/my-action
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
   });
 
   describe("invalid formats", () => {
@@ -327,6 +351,74 @@ jobs:
         }
       ]);
     });
+
+    it("self-reference with empty path", async () => {
+      const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([
+        {
+          message: "Expected format $/{path}. Actual '$/'",
+          severity: DiagnosticSeverity.Error,
+          range: {
+            start: {line: 5, character: 12},
+            end: {line: 5, character: 14}
+          },
+          code: "invalid-uses-format"
+        }
+      ]);
+    });
+
+    it("self-reference with version", async () => {
+      const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/composite@v1
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([
+        {
+          message:
+            "A version cannot be specified for self-references. Expected format $/{path}. Actual '$/actions/composite@v1'",
+          severity: DiagnosticSeverity.Error,
+          range: {
+            start: {line: 5, character: 12},
+            end: {line: 5, character: 34}
+          },
+          code: "invalid-uses-format"
+        }
+      ]);
+    });
+
+    it("self-reference to reusable workflow in step", async () => {
+      const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/.github/workflows/test.yml
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([
+        {
+          message:
+            "Reusable workflows should be referenced at the top-level `jobs.<job_id>.uses` key, not within steps",
+          severity: DiagnosticSeverity.Error,
+          range: {
+            start: {line: 5, character: 12},
+            end: {line: 5, character: 40}
+          },
+          code: "invalid-uses-format"
+        }
+      ]);
+    });
   });
 });
 
@@ -421,6 +513,36 @@ jobs:
 jobs:
   test:
     uses: owner/repo/.github/workflows-lab/test.yml@v1
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
+
+    it("self-reference workflow path", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/.github/workflows/test.yml
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
+
+    it("self-reference workflow path with yaml extension", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/.github/workflows/test.yaml
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
+
+    it("self-reference workflows-lab path", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/.github/workflows-lab/test.yml
 `;
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([]);
@@ -589,6 +711,69 @@ jobs:
           range: {
             start: {line: 3, character: 10},
             end: {line: 3, character: 30}
+          },
+          code: "invalid-workflow-uses-format"
+        }
+      ]);
+    });
+
+    it("self-reference workflow with version", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/.github/workflows/test.yml@main
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([
+        {
+          message:
+            "Invalid workflow reference '$/.github/workflows/test.yml@main': cannot specify version when calling self-referenced workflows",
+          severity: DiagnosticSeverity.Error,
+          range: {
+            start: {line: 3, character: 10},
+            end: {line: 3, character: 43}
+          },
+          code: "invalid-workflow-uses-format"
+        }
+      ]);
+    });
+
+    it("self-reference workflow not rooted in .github/workflows", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/workflows/test.yml
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([
+        {
+          message:
+            "Invalid workflow reference '$/workflows/test.yml': self-referenced workflows must be rooted in '.github/workflows'",
+          severity: DiagnosticSeverity.Error,
+          range: {
+            start: {line: 3, character: 10},
+            end: {line: 3, character: 30}
+          },
+          code: "invalid-workflow-uses-format"
+        }
+      ]);
+    });
+
+    it("self-reference workflow with invalid extension", async () => {
+      const input = `on: push
+jobs:
+  test:
+    uses: $/.github/workflows/test.txt
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([
+        {
+          message:
+            "Invalid workflow reference '$/.github/workflows/test.txt': workflow file should have either a '.yml' or '.yaml' file extension",
+          severity: DiagnosticSeverity.Error,
+          range: {
+            start: {line: 3, character: 10},
+            end: {line: 3, character: 38}
           },
           code: "invalid-workflow-uses-format"
         }

--- a/languageservice/src/validate.uses-format.test.ts
+++ b/languageservice/src/validate.uses-format.test.ts
@@ -386,7 +386,7 @@ jobs:
       expect(result).toEqual([
         {
           message:
-            "A version cannot be specified for self-references. Expected format $/{path}. Actual '$/actions/composite@v1'",
+            "A version cannot be specified for self repository references. Expected format $/{path}. Actual '$/actions/composite@v1'",
           severity: DiagnosticSeverity.Error,
           range: {
             start: {line: 5, character: 12},
@@ -727,7 +727,7 @@ jobs:
       expect(result).toEqual([
         {
           message:
-            "Invalid workflow reference '$/.github/workflows/test.yml@v1': cannot specify version when calling self-referenced workflows",
+            "Invalid workflow reference '$/.github/workflows/test.yml@v1': cannot specify version when calling self repository workflows",
           severity: DiagnosticSeverity.Error,
           range: {
             start: {line: 3, character: 10},

--- a/languageservice/src/validate.uses-format.test.ts
+++ b/languageservice/src/validate.uses-format.test.ts
@@ -129,7 +129,7 @@ jobs:
       expect(result).toEqual([]);
     });
 
-    it("self-reference with $/", async () => {
+    it("self repository reference with $/", async () => {
       const input = `on: push
 jobs:
   build:
@@ -141,7 +141,7 @@ jobs:
       expect(result).toEqual([]);
     });
 
-    it("self-reference with $/ and subdirectories", async () => {
+    it("self repository reference with $/ and subdirectories", async () => {
       const input = `on: push
 jobs:
   build:
@@ -352,7 +352,7 @@ jobs:
       ]);
     });
 
-    it("self-reference with empty path", async () => {
+    it("self repository reference with empty path", async () => {
       const input = `on: push
 jobs:
   build:
@@ -374,7 +374,7 @@ jobs:
       ]);
     });
 
-    it("self-reference with a ref", async () => {
+    it("self repository reference with a ref", async () => {
       const input = `on: push
 jobs:
   build:
@@ -397,7 +397,7 @@ jobs:
       ]);
     });
 
-    it("self-reference to reusable workflow in step", async () => {
+    it("self repository reference to reusable workflow in step", async () => {
       const input = `on: push
 jobs:
   build:
@@ -448,7 +448,7 @@ jobs:
       expect(result).toEqual([]);
     });
 
-    it("self-reference workflow path", async () => {
+    it("self repository workflow path", async () => {
       const input = `on: push
 jobs:
   test:
@@ -458,7 +458,7 @@ jobs:
       expect(result).toEqual([]);
     });
 
-    it("self-reference workflow path with yaml extension", async () => {
+    it("self repository workflow path with yaml extension", async () => {
       const input = `on: push
 jobs:
   test:
@@ -468,7 +468,7 @@ jobs:
       expect(result).toEqual([]);
     });
 
-    it("self-reference workflows-lab path", async () => {
+    it("self repository workflows-lab path", async () => {
       const input = `on: push
 jobs:
   test:
@@ -717,7 +717,7 @@ jobs:
       ]);
     });
 
-    it("self-reference workflow with @ref is not supported at job level", async () => {
+    it("self repository workflow with @ref is not supported at job level", async () => {
       const input = `on: push
 jobs:
   test:

--- a/languageservice/src/validate.uses-format.test.ts
+++ b/languageservice/src/validate.uses-format.test.ts
@@ -352,7 +352,7 @@ jobs:
       ]);
     });
 
-    it("self repository reference with empty path", async () => {
+    it("allows a self repository reference with an empty path like a local action path", async () => {
       const input = `on: push
 jobs:
   build:
@@ -361,20 +361,10 @@ jobs:
     - uses: $/
 `;
       const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([
-        {
-          message: "Expected format $/{path}. Actual '$/'",
-          severity: DiagnosticSeverity.Error,
-          range: {
-            start: {line: 5, character: 12},
-            end: {line: 5, character: 14}
-          },
-          code: "invalid-uses-format"
-        }
-      ]);
+      expect(result).toEqual([]);
     });
 
-    it("self repository reference with a ref", async () => {
+    it("allows a self repository reference with a ref like a local action path", async () => {
       const input = `on: push
 jobs:
   build:
@@ -383,21 +373,10 @@ jobs:
     - uses: $/actions/composite@v1
 `;
       const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([
-        {
-          message:
-            "A version cannot be specified for self repository references. Expected format $/{path}. Actual '$/actions/composite@v1'",
-          severity: DiagnosticSeverity.Error,
-          range: {
-            start: {line: 5, character: 12},
-            end: {line: 5, character: 34}
-          },
-          code: "invalid-uses-format"
-        }
-      ]);
+      expect(result).toEqual([]);
     });
 
-    it("self repository reference to reusable workflow in step", async () => {
+    it("allows a self repository workflow path in a step like a local action path", async () => {
       const input = `on: push
 jobs:
   build:
@@ -406,18 +385,7 @@ jobs:
     - uses: $/.github/workflows/test.yml
 `;
       const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([
-        {
-          message:
-            "Reusable workflows should be referenced at the top-level `jobs.<job_id>.uses` key, not within steps",
-          severity: DiagnosticSeverity.Error,
-          range: {
-            start: {line: 5, character: 12},
-            end: {line: 5, character: 40}
-          },
-          code: "invalid-uses-format"
-        }
-      ]);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/languageservice/src/validate.uses-format.test.ts
+++ b/languageservice/src/validate.uses-format.test.ts
@@ -152,6 +152,18 @@ jobs:
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([]);
     });
+
+    it("self-reference with $/ and a ref", async () => {
+      const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/composite@v1
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([]);
+    });
   });
 
   describe("invalid formats", () => {
@@ -363,34 +375,11 @@ jobs:
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([
         {
-          message: "Expected format $/{path}. Actual '$/'",
+          message: "Expected format $/{path}[@{ref}]. Actual '$/'",
           severity: DiagnosticSeverity.Error,
           range: {
             start: {line: 5, character: 12},
             end: {line: 5, character: 14}
-          },
-          code: "invalid-uses-format"
-        }
-      ]);
-    });
-
-    it("self-reference with version", async () => {
-      const input = `on: push
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: $/actions/composite@v1
-`;
-      const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([
-        {
-          message:
-            "A version cannot be specified for self-references. Expected format $/{path}. Actual '$/actions/composite@v1'",
-          severity: DiagnosticSeverity.Error,
-          range: {
-            start: {line: 5, character: 12},
-            end: {line: 5, character: 34}
           },
           code: "invalid-uses-format"
         }
@@ -513,36 +502,6 @@ jobs:
 jobs:
   test:
     uses: owner/repo/.github/workflows-lab/test.yml@v1
-`;
-      const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([]);
-    });
-
-    it("self-reference workflow path", async () => {
-      const input = `on: push
-jobs:
-  test:
-    uses: $/.github/workflows/test.yml
-`;
-      const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([]);
-    });
-
-    it("self-reference workflow path with yaml extension", async () => {
-      const input = `on: push
-jobs:
-  test:
-    uses: $/.github/workflows/test.yaml
-`;
-      const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([]);
-    });
-
-    it("self-reference workflows-lab path", async () => {
-      const input = `on: push
-jobs:
-  test:
-    uses: $/.github/workflows-lab/test.yml
 `;
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([]);
@@ -717,59 +676,16 @@ jobs:
       ]);
     });
 
-    it("self-reference workflow with version", async () => {
+    it("self-reference workflow is not supported at job level", async () => {
       const input = `on: push
 jobs:
   test:
-    uses: $/.github/workflows/test.yml@main
+    uses: $/.github/workflows/test.yml
 `;
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([
         {
-          message:
-            "Invalid workflow reference '$/.github/workflows/test.yml@main': cannot specify version when calling self-referenced workflows",
-          severity: DiagnosticSeverity.Error,
-          range: {
-            start: {line: 3, character: 10},
-            end: {line: 3, character: 43}
-          },
-          code: "invalid-workflow-uses-format"
-        }
-      ]);
-    });
-
-    it("self-reference workflow not rooted in .github/workflows", async () => {
-      const input = `on: push
-jobs:
-  test:
-    uses: $/workflows/test.yml
-`;
-      const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([
-        {
-          message:
-            "Invalid workflow reference '$/workflows/test.yml': self-referenced workflows must be rooted in '.github/workflows'",
-          severity: DiagnosticSeverity.Error,
-          range: {
-            start: {line: 3, character: 10},
-            end: {line: 3, character: 30}
-          },
-          code: "invalid-workflow-uses-format"
-        }
-      ]);
-    });
-
-    it("self-reference workflow with invalid extension", async () => {
-      const input = `on: push
-jobs:
-  test:
-    uses: $/.github/workflows/test.txt
-`;
-      const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([
-        {
-          message:
-            "Invalid workflow reference '$/.github/workflows/test.txt': workflow file should have either a '.yml' or '.yaml' file extension",
+          message: "Invalid workflow reference '$/.github/workflows/test.yml': no version specified",
           severity: DiagnosticSeverity.Error,
           range: {
             start: {line: 3, character: 10},

--- a/languageservice/src/validate.uses-format.test.ts
+++ b/languageservice/src/validate.uses-format.test.ts
@@ -152,18 +152,6 @@ jobs:
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([]);
     });
-
-    it("self-reference with $/ and a ref", async () => {
-      const input = `on: push
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: $/actions/composite@v1
-`;
-      const result = await validate(createDocument("wf.yaml", input));
-      expect(result).toEqual([]);
-    });
   });
 
   describe("invalid formats", () => {
@@ -375,11 +363,34 @@ jobs:
       const result = await validate(createDocument("wf.yaml", input));
       expect(result).toEqual([
         {
-          message: "Expected format $/{path}[@{ref}]. Actual '$/'",
+          message: "Expected format $/{path}. Actual '$/'",
           severity: DiagnosticSeverity.Error,
           range: {
             start: {line: 5, character: 12},
             end: {line: 5, character: 14}
+          },
+          code: "invalid-uses-format"
+        }
+      ]);
+    });
+
+    it("self-reference with a ref", async () => {
+      const input = `on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: $/actions/composite@v1
+`;
+      const result = await validate(createDocument("wf.yaml", input));
+      expect(result).toEqual([
+        {
+          message:
+            "A version cannot be specified for self-references. Expected format $/{path}. Actual '$/actions/composite@v1'",
+          severity: DiagnosticSeverity.Error,
+          range: {
+            start: {line: 5, character: 12},
+            end: {line: 5, character: 34}
           },
           code: "invalid-uses-format"
         }

--- a/workflow-parser/src/model/converter/steps.ts
+++ b/workflow-parser/src/model/converter/steps.ts
@@ -130,7 +130,7 @@ function createActionStepId(step: ActionStep): string {
     return "self";
   }
 
-  // Self-reference ($/path): resolved from the same repository as the executing
+  // Self repository reference ($/path): resolved from the same repository as the executing
   // workflow/action.
   if (uses.startsWith("$/")) {
     return "self";

--- a/workflow-parser/src/model/converter/steps.ts
+++ b/workflow-parser/src/model/converter/steps.ts
@@ -130,6 +130,12 @@ function createActionStepId(step: ActionStep): string {
     return "self";
   }
 
+  // Self-reference ($/path): resolved from the same repository as the executing
+  // workflow/action.
+  if (uses.startsWith("$/")) {
+    return "self";
+  }
+
   const segments = uses.split("@");
   if (segments.length != 2) {
     return "";

--- a/workflow-parser/src/workflows/file-reference.test.ts
+++ b/workflow-parser/src/workflows/file-reference.test.ts
@@ -15,13 +15,6 @@ describe("parseFileReference", () => {
     });
   });
 
-  it("parses self-reference file reference", () => {
-    const ref = parseFileReference("$/.github/workflows/test.yml");
-    expect(ref).toEqual({
-      path: ".github/workflows/test.yml"
-    });
-  });
-
   it("parses remote file reference", () => {
     const ref = parseFileReference("owner/repo/path@version");
     expect(ref).toEqual({

--- a/workflow-parser/src/workflows/file-reference.test.ts
+++ b/workflow-parser/src/workflows/file-reference.test.ts
@@ -1,4 +1,4 @@
-import {parseFileReference} from "./file-reference.js";
+import {fileIdentifier, parseFileReference} from "./file-reference.js";
 
 describe("parseFileReference", () => {
   it("parses local file reference", () => {
@@ -13,6 +13,27 @@ describe("parseFileReference", () => {
     expect(ref).toEqual({
       path: ""
     });
+  });
+
+  it("parses self file reference", () => {
+    const ref = parseFileReference("$/.github/workflows/build.yml");
+    expect(ref).toEqual({
+      path: ".github/workflows/build.yml"
+    });
+  });
+
+  it("parses self file references with an empty path", () => {
+    const ref = parseFileReference("$/");
+    expect(ref).toEqual({
+      path: ""
+    });
+  });
+
+  it("normalizes self file references to the same identifier as local references", () => {
+    const selfRef = parseFileReference("$/.github/workflows/build.yml");
+    const localRef = parseFileReference("./.github/workflows/build.yml");
+    expect(fileIdentifier(selfRef)).toEqual(fileIdentifier(localRef));
+    expect(fileIdentifier(selfRef)).toEqual("./.github/workflows/build.yml");
   });
 
   it("parses remote file reference", () => {

--- a/workflow-parser/src/workflows/file-reference.test.ts
+++ b/workflow-parser/src/workflows/file-reference.test.ts
@@ -15,6 +15,13 @@ describe("parseFileReference", () => {
     });
   });
 
+  it("parses self-reference file reference", () => {
+    const ref = parseFileReference("$/.github/workflows/test.yml");
+    expect(ref).toEqual({
+      path: ".github/workflows/test.yml"
+    });
+  });
+
   it("parses remote file reference", () => {
     const ref = parseFileReference("owner/repo/path@version");
     expect(ref).toEqual({

--- a/workflow-parser/src/workflows/file-reference.ts
+++ b/workflow-parser/src/workflows/file-reference.ts
@@ -18,6 +18,14 @@ export function parseFileReference(ref: string): FileReference {
     };
   }
 
+  // Self-reference: `$/<path>` resolves within the same repository at the running
+  // SHA, exactly like `./` for local references.
+  if (ref.startsWith("$/")) {
+    return {
+      path: ref.substring(2)
+    };
+  }
+
   const [remotePath, version] = ref.split("@");
   const [owner, repository, ...pathSegments] = remotePath.split("/").filter(s => s.length > 0);
 

--- a/workflow-parser/src/workflows/file-reference.ts
+++ b/workflow-parser/src/workflows/file-reference.ts
@@ -18,7 +18,7 @@ export function parseFileReference(ref: string): FileReference {
     };
   }
 
-  // Self-reference: `$/<path>` resolves within the same repository at the running
+  // Self repository reference: `$/<path>` resolves within the same repository at the running
   // SHA, exactly like `./` for local references.
   if (ref.startsWith("$/")) {
     return {

--- a/workflow-parser/src/workflows/file-reference.ts
+++ b/workflow-parser/src/workflows/file-reference.ts
@@ -18,14 +18,6 @@ export function parseFileReference(ref: string): FileReference {
     };
   }
 
-  // Self-reference ($/path): a file resolved from the same repository as the executing
-  // workflow/action. Treated as a repo-root-relative local path.
-  if (ref.startsWith("$/")) {
-    return {
-      path: ref.substring(2)
-    };
-  }
-
   const [remotePath, version] = ref.split("@");
   const [owner, repository, ...pathSegments] = remotePath.split("/").filter(s => s.length > 0);
 

--- a/workflow-parser/src/workflows/file-reference.ts
+++ b/workflow-parser/src/workflows/file-reference.ts
@@ -18,6 +18,14 @@ export function parseFileReference(ref: string): FileReference {
     };
   }
 
+  // Self-reference ($/path): a file resolved from the same repository as the executing
+  // workflow/action. Treated as a repo-root-relative local path.
+  if (ref.startsWith("$/")) {
+    return {
+      path: ref.substring(2)
+    };
+  }
+
   const [remotePath, version] = ref.split("@");
   const [owner, repository, ...pathSegments] = remotePath.split("/").filter(s => s.length > 0);
 


### PR DESCRIPTION
Teaches the language service to understand the `$/` self repository `uses:` syntax so the workflow and action editors validate it correctly.

- Accepts bare `$/<path>` wherever a same-repository reference is valid: action steps, composite-action steps, and job-level reusable-workflow calls.
- Rejects `$/…@ref` — a self repository reference is inherently pinned to the running commit and cannot specify a version.
- Resolves the target within the same repository, reporting a missing `action.yml` or an out-of-tree workflow path.

Pairs with the `$/` self repository support landing across the parser, launch, and pin tooling.